### PR TITLE
Add sections to docs

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,0 +1,10 @@
+# Advanced Configuration
+
+## `mysql.conf`
+
+You can customize Nitro’s MySQL settings by editing `mysql.conf` and restarting the MySQL service:
+
+1. Tunnel into the machine with `nitro ssh`.
+2. Apply your changes to `~/.nitro/databases/mysql/conf.d/mysql.conf`.
+3. Exit the machine tunnel by running `exit`.
+4. Restart MySQL using `nitro db restart`.

--- a/MAILHOG.md
+++ b/MAILHOG.md
@@ -1,0 +1,28 @@
+# Using MailHog with Craft
+
+Nitro comes with [MailHog](https://github.com/mailhog/MailHog) for convenient local email testing and development.
+
+## Set Up MailHog
+
+MailHog requires setup for each machine you’d like to use it on. Run this command to spin it up:
+
+```sh
+nitro mailhog
+```
+
+## Configure Craft Email for MailHog
+
+MailHog’s ready to be used once it’s running, but it doesn’t change any of your mail setitngs by default. You can tell Craft or any app to send mail using MailHog’s SMTP settings.
+
+From the Craft control panel, visit Settings → Email and enter the following:
+
+- Transport Type: `SMTP`
+- Host Name: `127.0.0.1`
+- Port: `1025`
+- Use Authentication: Unchecked (default)
+- Encryption Method: `None` (default)
+- Timeout: `10` (default)
+
+## Access MailHog GUI
+
+Once it’s running, the MailHog front end will be available at `http://[machine-ip]:8025`. After Craft is configured to use MailHog you should see the test email appear in its inbox.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Nitro is a speedy local development environment that’s tuned for [Craft CMS](h
   - [Adding a site with `nitro add`](#add-a-site-with-nitro-add)
   - [Mounting your entire dev folder at once](#mounting-your-entire-dev-folder-at-once)
 - [Connecting to the Database](#connecting-to-the-database)
+- [Adding a Database](#adding-a-database)
 - [Adding Mounts](#adding-mounts)
 - [Running Multiple Machines](#running-multiple-machines)
 - [Adding Multiple Database Engines](#adding-multiple-database-engines)
 - [Using Blackfire](#using-blackfire)
 - [Using Xdebug](#using-xdebug)
+- [Using MailHog](#using-mailhog)
+- [Advanced Configuration](#advanced-configuration)
 - [Commands](#commands)
   - [`apply`](#apply)
   - [`add`](#add)
@@ -194,6 +197,14 @@ Then from your SQL client of choice, create a new database connection with the f
 - **Username**: `nitro`
 - **Password**: `nitro`
 
+## Adding a Database
+
+Nitro creates its initial database for you. You can add as many as you’d like running the following command, which will prompt for your desired database engine and name:
+
+```sh
+$ nitro db add
+```
+
 ## Adding Mounts
 
 Nitro can mount various system directories into your Nitro machine. You can either mount each of your projects’
@@ -265,6 +276,14 @@ See [Using Blackfire with Nitro](BLACKFIRE.md) for instructions on how to config
 ## Using Xdebug
 
 See [Using Xdebug with Nitro and PhpStorm](XDEBUG.md) for instructions on how to configure Xdebug and PhpStorm for web/console debugging.
+
+## Using MailHog
+
+See [Using MailHog with Craft](MAILHOG.md) for instructions on configuring Craft to send email to MailHog for local development and troubleshooting.
+
+## Advanced Configuration
+
+See [Advanced Configuration](ADVANCED.md) for instructions on customizing Nitro’s default settings.
 
 ## Commands
 


### PR DESCRIPTION
This adds three things:

1. Brief _Adding a Database_ section for the readme.
2. An `ADVANCED.md` markdown file that covers customizing `mysql.conf` and could be expanded to cover any other adjustments to the web server or any of its services.
3. A `MAILHOG.md` markdown file that covers MailHog setup and access. (Felt potentially long for the readme.)

Submitting as a PR in case any of this is offensive. Let me know and I can season to taste!