### PR TITLE
Spiff up Xdebug PhpStorm setup instructions.

### DIFF
--- a/XDEBUG.md
+++ b/XDEBUG.md
@@ -1,10 +1,27 @@
 # Using Xdebug with Nitro and PhpStorm
 
-Once you have a machine created, you can run `nitro xdebug on` and `nitro xdebug configure` to enable Xdebug and set it up for automatic remote connections from your host machine. These make the 
+Once you’ve created a machine, you can run `nitro xdebug on` and `nitro xdebug configure` to enable [Xdebug](https://xdebug.org/) and set it up for automatic connections from your host machine.
 
-## Debugging web requests
+You can use `nitro xdebug off` to disable Xdebug without having to restart the machine.
 
-Install the Xdebug browser helper in your favorite browser.
+## Configuring PhpStorm
+
+First, you’ll need to configure PhpStorm to listen for requests from the browser or console.
+
+1. Create a new server in PhpStorm using your machine’s domain name. (“Preferences” → “Languages & Frameworks” → “PHP” → “Servers”.)  
+![PhpStorm Server Settings](resources/phpstorm_server.png)
+
+2. Enable “Use path mappings” and set your existing project root to the absolute path on the server. The absolute path will look like `/home/ubuntu/sites/my-site`, where `my-site` reflects your actual project’s folder name in the Nitro machine. (Use `nitro context` if you need to check the path, and keep in mind this is the project root and not necessarily the web root.)
+
+3. Choose “Run” → “Edit Configurations...” and create a new “PHP Remote Debug” configuration, selecting the server you just created. Check “Filter debug connection by IDE key” and enter `PHPSTORM`.  
+![PhpStorm Remote Debug Settings](resources/phpstorm_remote_debug.png)
+
+4. Choose “Run” → “Start Listening for PHP Debug Connections”.  
+![PhpStorm Remote Debug Settings](resources/start_listening.png)
+
+## Debugging Web Requests
+
+1. Install the Xdebug helper in your favorite browser.
 
 - [Chrome](https://chrome.google.com/extensions/detail/eadndfjplgieldjbigjakmdgkmoaaaoc)
 - [Firefox](https://addons.mozilla.org/en-US/firefox/addon/xdebug-helper-for-firefox/)
@@ -12,35 +29,14 @@ Install the Xdebug browser helper in your favorite browser.
 - [Safari](https://github.com/benmatselby/xdebug-toggler)
 - [Opera](https://addons.opera.com/addons/extensions/details/xdebug-launcher/)
 
-Go to the Xdebug browser helper options, choose "PhpStorm" and save.
-
+2. In the browser helper’s options, choose “PhpStorm” and save.  
 ![Xdebug Browser Helper Chrome](resources/xdebug_chrome_settings.png)
 
-Create a new server in PhpStorm using your machine's domain name.
-
-![PhpStorm Server Settings](resources/phpstorm_server.png)
-
-Setup path mappings to that `/app/sites/example.test` in your Nitro machine is
-mapped to your project's root on your host machine.
-
-Create a new "PHP Remote Debug" configuration and select the server you just created.
-
-Check "Filter debug connection by IDE key" and enter "PHPSTORM" for the IDE key.
-
-![PhpStorm Remote Debug Settings](resources/phpstorm_remote_debug.png)
-
-Click the "Start Listening for PHP Debug Connections" button in PhpStorm.
-
-![PhpStorm Remote Debug Settings](resources/start_listening.png)
-
-Click the "Debug" button on your browser's Xdebug helper.
-
+3. Choose “Debug” on your browser’s Xdebug helper.  
 ![PhpStorm Remote Debug Settings](resources/xdebug_chrome.png)
 
-Then load the site in your browser and whatever breakpoints you've set will be hit.
+4. Load the site in your browser and whatever breakpoints you’ve set will be hit.
 
 ## Debugging PHP console requests
 
-Do everything above except Xdebug browser helper. SSH into your Nitro machine using
-`nitro ssh`, then run your PHP script from the console and any breakpoints you've
-set will be hit.
+SSH into your Nitro machine using `nitro ssh`, then run your PHP script from the console and any breakpoints you’ve set will be hit.

--- a/XDEBUG.md
+++ b/XDEBUG.md
@@ -37,6 +37,6 @@ First, you’ll need to configure PhpStorm to listen for requests from the brows
 
 4. Load the site in your browser and whatever breakpoints you’ve set will be hit.
 
-## Debugging PHP console requests
+## Debugging Console Requests
 
 SSH into your Nitro machine using `nitro ssh`, then run your PHP script from the console and any breakpoints you’ve set will be hit.


### PR DESCRIPTION
Separated out and started with PhpStorm setup, with explicit sections for browser and console debugging. Also added hints about where to find things, and corrected the example Nitro path for accuracy.