### PR TITLE
Fix individual DB export on destroy

### DIFF
--- a/internal/cmd/destroy.go
+++ b/internal/cmd/destroy.go
@@ -132,7 +132,7 @@ var destroyCommand = &cobra.Command{
 						}
 
 						fullVmBackupPath = "/home/ubuntu/.nitro/databases/mysql/backups/" + backupFileName
-						if output, err := script.Run(false, fmt.Sprintf(scripts.FmtDockerBackupAllMysqlDatabases, container, fullVmBackupPath)); err != nil {
+						if output, err := script.Run(false, fmt.Sprintf(scripts.FmtDockerBackupIndividualMysqlDatabase, container, fullVmBackupPath)); err != nil {
 							fmt.Println(output)
 							fmt.Println(err)
 							fmt.Println(backupErrorMessage)


### PR DESCRIPTION
When destroying the machine, Nitro would create multiple backups, all containing **all** databases.
