### PR TITLE
Update WSL cert message to mention administrator rights being needed

### DIFF
--- a/pkg/certinstall/certinstall.go
+++ b/pkg/certinstall/certinstall.go
@@ -75,7 +75,7 @@ func Install(file, system string) error {
 		// is this a wsl machine?
 		if dist, exists := os.LookupEnv("WSL_DISTRO_NAME"); exists {
 			user := os.Getenv("USER")
-			fmt.Println("Users on WSL will need to open a command prompt or terminal on Windows and run the following command:")
+			fmt.Println("Users on WSL will need to open an elevated (run as administrator) Command Prompt or terminal on Windows and run the following command:")
 			fmt.Printf(`certutil -addstore -f "Root" \\wsl$\%s\home\%s\.nitro\nitro.crt\n`, dist, user)
 		}
 	default:


### PR DESCRIPTION
### Description

To install the Caddy Nitro root certificate on Windows hosts requires administrator privileges. The command can be run from Command Prompt, PowerShell, Windows Terminal etc, but whatever shell is used on the Windows host, it needs to be elevated.

This updates the guidance message to directly mention this to help the WSL users with the certificate install step.

