### PR TITLE
Check for arch linux distribution

### DIFF
--- a/pkg/certinstall/certinstall.go
+++ b/pkg/certinstall/certinstall.go
@@ -89,7 +89,7 @@ func Install(file, system string) error {
 }
 
 func findLinuxDistribution(description string) (string, error) {
-	if strings.Contains(description, "Manjaro") {
+	if strings.Contains(description, "Manjaro") || strings.Contains(description, "Arch Linux") {
 		return "arch", nil
 	}
 


### PR DESCRIPTION
### Description

Currently, nitro is unable to identify arch linux for installing the certificate because it does not check for this distribution name. With this change it becomes possible to initialise nitro also on arch linux.

_Without change (on arch linux):_
```
~$ NITRO_DEVELOPMENT=true nitro init
[...]
  … getting Nitro’s root site certificate… ✓
Installing certificate (you might be prompted for your password)
Error: unable to find the distribution from the description: Description:       Arch Linux
```

_With change (on arch linux):_
```
~$ NITRO_DEVELOPMENT=true nitro init 
[...]
  … getting Nitro’s root site certificate… ✓
Installing certificate (you might be prompted for your password)
Nitro certificates are now trusted 🔒
Nitro is ready! 🚀
```