### PR TITLE
Add Linux Mint to distro finder

### DIFF
--- a/pkg/certinstall/certinstall.go
+++ b/pkg/certinstall/certinstall.go
@@ -97,7 +97,7 @@ func findDistro(description string) (string, error) {
 	}
 
 	// detect debian systems
-	if strings.Contains(description, "Ubuntu") || strings.Contains(description, "Pop!_OS" || strings.Contains(description, "Mint") {
+	if strings.Contains(description, "Ubuntu") || strings.Contains(description, "Pop!_OS") || strings.Contains(description, "Mint") {
 		return "debian", nil
 	}
 

--- a/pkg/certinstall/certinstall.go
+++ b/pkg/certinstall/certinstall.go
@@ -97,7 +97,7 @@ func findDistro(description string) (string, error) {
 	}
 
 	// detect debian systems
-	if strings.Contains(description, "Ubuntu") || strings.Contains(description, "Pop!_OS") {
+	if strings.Contains(description, "Ubuntu") || strings.Contains(description, "Pop!_OS" || strings.Contains(description, "Mint") {
 		return "debian", nil
 	}
 


### PR DESCRIPTION
The certificate installation fails on Linux Mint because it is not recognized as Debian based system.

This is the ouput of the `lsb_release` command on Linux Mint 20:

![image](https://user-images.githubusercontent.com/16897125/110760310-e1114f00-824e-11eb-9725-965cc065ff0e.png)


