### PR TITLE
Fix typo.

### DIFF
--- a/command/selfupdate/selfupdate.go
+++ b/command/selfupdate/selfupdate.go
@@ -151,7 +151,7 @@ func NewCommand(output terminal.Outputer) *cobra.Command {
 						if file.Name == "nitro.exe" {
 							output.Done()
 
-							output.Info("Updating to Nitro", release.Version+"!")
+							output.Info("Updated to Nitro", release.Version+"!")
 
 							// read the file
 							f, err := os.Open(file.FileInfo().Name())


### PR DESCRIPTION
### Description

If a person was to self-update right now, they’d see...

```
$ nitro self-update
Checking for updates
  … found version 2.0.6 updating ✓
Updating to Nitro 2.0.6!
```

Seeing as how the `…` → `✓` transition is where all the fun happened, the last line should probably report “Updat**ed**” instead of “Updat**ing**”.

This elegant PR solves for that:

```
$ nitro self-update
Checking for updates
  … found version 2.0.6 updating ✓
Updated to Nitro 2.0.6!
```