### PR TITLE
Revise short command descriptions.

### DIFF
--- a/command/add/add.go
+++ b/command/add/add.go
@@ -27,7 +27,7 @@ const exampleText = `  # add the current directory as a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add",
-		Short:   "Add a site",
+		Short:   "Adds a site.",
 		Example: exampleText,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/alias/alias.go
+++ b/command/alias/alias.go
@@ -21,7 +21,7 @@ const exampleText = `  # add alias domains to a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "alias",
-		Short:   "Add alias domains",
+		Short:   "Adds alias domains.",
 		Example: exampleText,
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.RunApply(cmd, args, false, output)

--- a/command/apply/apply.go
+++ b/command/apply/apply.go
@@ -55,7 +55,7 @@ const exampleText = `  # apply changes from a config
 func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "apply",
-		Short:   "Apply changes",
+		Short:   "Applies changes.",
 		Example: exampleText,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// is the docker api alive?

--- a/command/blackfire/blackfire.go
+++ b/command/blackfire/blackfire.go
@@ -17,7 +17,7 @@ const exampleText = `  # enable blackfire for a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "blackfire",
-		Short:   "Manage Blackfire credentials",
+		Short:   "Manages Blackfire credentials.",
 		Example: exampleText,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/blackfire/off.go
+++ b/command/blackfire/off.go
@@ -16,7 +16,7 @@ const offText = `  # disable blackfire for a site
 func offCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "off",
-		Short:   "Disable blackfire for a site",
+		Short:   "Disables Blackfire for a site.",
 		Example: offText,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/blackfire/on.go
+++ b/command/blackfire/on.go
@@ -17,7 +17,7 @@ const onTest = `  # enable blackfire for a site
 func onCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "on",
-		Short:   "Enable blackfire for a site",
+		Short:   "Enables Blackfire for a site.",
 		Example: onTest,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/bridge/bridge.go
+++ b/command/bridge/bridge.go
@@ -31,7 +31,7 @@ const exampleText = `  # bridge your network ip to share nitro on the local netw
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "bridge",
-		Short:   "Share sites on your local network",
+		Short:   "Shares sites on your local network.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/clean/clean.go
+++ b/command/clean/clean.go
@@ -18,7 +18,7 @@ const exampleText = `  # remove unused containers
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "clean",
-		Short:   "Remove unused containers",
+		Short:   "Removes unused containers.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			output.Info("Cleaning up…")

--- a/command/completion/completion.go
+++ b/command/completion/completion.go
@@ -36,7 +36,7 @@ $ nitro completion zsh > "${fpath[1]}/_nitro"
 func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:       "completion",
-		Short:     "Enable shell completion",
+		Short:     "Enables shell completion.",
 		ValidArgs: []string{"bash", "zsh"},
 		Example:   exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/composer/composer.go
+++ b/command/composer/composer.go
@@ -40,7 +40,7 @@ const exampleText = `  # run composer install in a current directory using a con
 func NewCommand(docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "composer",
-		Short:              "Run composer commands",
+		Short:              "Runs a Composer command.",
 		Example:            exampleText,
 		DisableFlagParsing: true,
 		Args:               cobra.MinimumNArgs(1),

--- a/command/container/container.go
+++ b/command/container/container.go
@@ -20,7 +20,7 @@ const exampleText = `  # manage custom containers
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "container",
-		Short:   "Manage custom containers",
+		Short:   "Manages custom containers.",
 		Example: exampleText,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/container/new.go
+++ b/command/container/new.go
@@ -21,7 +21,7 @@ import (
 func newCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "new",
-		Short: "Add a new custom container",
+		Short: "Adds a new custom container.",
 		Example: `  # add a new custom container
   nitro container new
 

--- a/command/container/remove.go
+++ b/command/container/remove.go
@@ -14,7 +14,7 @@ import (
 func removeCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove",
-		Short: "Remove custom container",
+		Short: "Removes a custom container.",
 		Example: `  # remove a custom container from the config
   nitro container remove`,
 		Aliases: []string{"rm"},

--- a/command/container/ssh.go
+++ b/command/container/ssh.go
@@ -20,7 +20,7 @@ var sshExampleText = `  # ssh into a custom container
 func sshCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ssh",
-		Short:   "SSH into custom container",
+		Short:   "Opens a shell in a custom container.",
 		Example: sshExampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// add filters to show only the environment and database containers

--- a/command/context/context.go
+++ b/command/context/context.go
@@ -21,7 +21,7 @@ const exampleText = `  # view all resources for the environment
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "context",
-		Short:   "View environment information",
+		Short:   "Displays environment information.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// load the config file

--- a/command/craft/craft.go
+++ b/command/craft/craft.go
@@ -31,7 +31,7 @@ const exampleText = `  # run craft console command in a sites container
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "craft",
-		Short:              "Run Craft console commands",
+		Short:              "Runs a Craft console command.",
 		DisableFlagParsing: true,
 		Example:            exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/create/create.go
+++ b/command/create/create.go
@@ -34,7 +34,7 @@ const exampleText = `  # create a new default craft project (similar to "compose
 func NewCommand(home string, docker client.CommonAPIClient, getter downloader.Getter, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
-		Short:   "Create project",
+		Short:   "Creates a site from a Composer project.",
 		Example: exampleText,
 		Args:    cobra.MinimumNArgs(1),
 		PostRunE: func(cmd *cobra.Command, args []string) error {

--- a/command/database/add.go
+++ b/command/database/add.go
@@ -25,7 +25,7 @@ var addExampleTest = `  # add a new database
 func addCommand(docker client.CommonAPIClient, nitrod protob.NitroClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add",
-		Short:   "Add a new database",
+		Short:   "Adds a new database.",
 		Example: addExampleTest,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// add filters to show only the environment and database containers

--- a/command/database/backup.go
+++ b/command/database/backup.go
@@ -27,7 +27,7 @@ var backupExampleText = `  # backup a database
 func backupCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "backup",
-		Short:   "Backup a database",
+		Short:   "Backs up a database.",
 		Example: backupExampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/command/database/database.go
+++ b/command/database/database.go
@@ -21,7 +21,7 @@ const exampleText = `  # import a database from a backup
 func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "db",
-		Short:   "Manage databases",
+		Short:   "Manages databases.",
 		Aliases: []string{"database"},
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/database/import.go
+++ b/command/database/import.go
@@ -41,7 +41,7 @@ var nameFlag string
 func importCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import",
-		Short: "Import a database",
+		Short: "Imports a database dump.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Println(cmd.UsageString())

--- a/command/database/new.go
+++ b/command/database/new.go
@@ -18,7 +18,7 @@ var newExampleTest = `  # add a new database engine
 func newCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "new",
-		Short:   "Add a database engine",
+		Short:   "Adds a database engine.",
 		Example: newExampleTest,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/database/remove.go
+++ b/command/database/remove.go
@@ -24,7 +24,7 @@ var removeExampleText = `  # remove a database
 func removeCommand(docker client.CommonAPIClient, nitrod protob.NitroClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove",
-		Short:   "Remove a database",
+		Short:   "Removes a database.",
 		Example: removeExampleText,
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/database/ssh.go
+++ b/command/database/ssh.go
@@ -20,7 +20,7 @@ var sshExampleText = `  # ssh into a database container
 func sshCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ssh",
-		Short:   "SSH into a db container",
+		Short:   "Opens a shell in a database container.",
 		Example: sshExampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// add filters to show only the environment and database containers

--- a/command/destroy/destroy.go
+++ b/command/destroy/destroy.go
@@ -42,7 +42,7 @@ const exampleText = `  # remove all resources (networks, containers, and volumes
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "destroy",
-		Short:   "Destroy resources",
+		Short:   "Destroys Nitro’s Docker resources.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/command/disable/disable.go
+++ b/command/disable/disable.go
@@ -32,7 +32,7 @@ const exampleText = `  # disable services
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable",
-		Short: "Disable services",
+		Short: "Disables a service.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Println(cmd.UsageString())

--- a/command/edit/edit.go
+++ b/command/edit/edit.go
@@ -17,7 +17,7 @@ const exampleText = `  # edit the config file
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "edit",
-		Short:   "Edit the nitro config",
+		Short:   "Opens Nitro’s config in the default editor.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(home)

--- a/command/enable/enable.go
+++ b/command/enable/enable.go
@@ -35,7 +35,7 @@ const exampleText = `  # enable services
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable",
-		Short: "Enable services",
+		Short: "Enables a service.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Println(cmd.UsageString())

--- a/command/extensions/extensions.go
+++ b/command/extensions/extensions.go
@@ -27,7 +27,7 @@ const exampleText = `  # enable PHP extensions for a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "extensions",
-		Short:   "Add PHP extensions to a site",
+		Short:   "Enables a PHP extension for a site.",
 		Example: exampleText,
 		Aliases: []string{"ext"},
 		PostRunE: func(cmd *cobra.Command, args []string) error {

--- a/command/hosts/hosts.go
+++ b/command/hosts/hosts.go
@@ -20,7 +20,7 @@ const exampleText = `  # modify hosts file to match sites and aliases
 func NewCommand(home string, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "hosts",
-		Short:   "Modify your hosts file",
+		Short:   "Modifies hosts file.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hosts := cmd.Flag("hostnames").Value.String()

--- a/command/hosts/remove.go
+++ b/command/hosts/remove.go
@@ -16,7 +16,7 @@ import (
 func removeCommand(home string, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove",
-		Short: "Remove nitro entries from hosts file",
+		Short: "Removes Nitro entries from hosts file.",
 		Example: `  # remove nitro entries from your hosts file
   nitro hosts remove`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/iniset/iniset.go
+++ b/command/iniset/iniset.go
@@ -29,7 +29,7 @@ const exampleText = `  # change PHP settings for a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "iniset",
-		Short:   "Change PHP setting",
+		Short:   "Changes a site’s PHP setting.",
 		Example: exampleText,
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.RunApply(cmd, args, false, output)

--- a/command/initialize/initialize.go
+++ b/command/initialize/initialize.go
@@ -27,7 +27,7 @@ var skipApply, skipTrust bool
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "init",
-		Short:         "Perform Nitro’s initial setup.",
+		Short:         "Performs Nitro’s initial setup.",
 		Example:       exampleText,
 		SilenceErrors: false,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/command/initialize/initialize.go
+++ b/command/initialize/initialize.go
@@ -27,7 +27,7 @@ var skipApply, skipTrust bool
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "init",
-		Short:         "Setup nitro",
+		Short:         "Perform Nitro’s initial setup.",
 		Example:       exampleText,
 		SilenceErrors: false,
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/command/logs/logs.go
+++ b/command/logs/logs.go
@@ -31,7 +31,7 @@ const exampleText = `  # show logs from a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "logs",
-		Short:   "View container logs",
+		Short:   "Displays container logs.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// get the current working directory

--- a/command/ls/ls.go
+++ b/command/ls/ls.go
@@ -30,7 +30,7 @@ var (
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls",
-		Short:   "Show Nitro info",
+		Short:   "Lists details for Nitro’s containers.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/command/nitro/nitro.go
+++ b/command/nitro/nitro.go
@@ -55,8 +55,8 @@ import (
 
 var rootCommand = &cobra.Command{
 	Use:   "nitro",
-	Short: "Local Craft CMS dev made easy",
-	Long: `Nitro is a command-line tool focused on making local Craft CMS development quick and easy.
+	Short: "Speedy local dev environment for Craft CMS.",
+	Long: `Nitro is a console-based tool that manages Docker for local PHP development.
 
 Version: ` + version.Version,
 	RunE:         rootMain,

--- a/command/npm/npm.go
+++ b/command/npm/npm.go
@@ -43,7 +43,7 @@ const exampleText = `  # run npm install in a current directory
 func NewCommand(docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "npm",
-		Short:   "Run npm commands",
+		Short:   "Runs an npm command.",
 		Example: exampleText,
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/permissions/permissions.go
+++ b/command/permissions/permissions.go
@@ -63,7 +63,7 @@ var files = []file{
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "permissions",
-		Short:   "Fix Craft permissions",
+		Short:   "Fixes Craft permissions.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/php/php.go
+++ b/command/php/php.go
@@ -26,7 +26,7 @@ const exampleText = `  # run php version
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "php",
-		Short:              "Run PHP commands",
+		Short:              "Runs PHP commands.",
 		Example:            exampleText,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/portcheck/portcheck.go
+++ b/command/portcheck/portcheck.go
@@ -21,7 +21,7 @@ const exampleText = `  # check if a port is in use
 func NewCommand(output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "portcheck",
-		Short:   "Check a local port",
+		Short:   "Checks whether a local port is available.",
 		Args:    cobra.MinimumNArgs(1),
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/queue/queue.go
+++ b/command/queue/queue.go
@@ -23,7 +23,7 @@ const exampleText = `  # execute the craft queue command for a site
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "queue",
-		Short:              "Run a queue worker",
+		Short:              "Runs a queue worker.",
 		DisableFlagParsing: true,
 		Example:            exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/share/share.go
+++ b/command/share/share.go
@@ -30,7 +30,7 @@ const exampleText = `  # share a local site with ngrok
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "share",
-		Short:   "Share a local site",
+		Short:   "Shares a local site.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/ssh/ssh_darwin.go
+++ b/command/ssh/ssh_darwin.go
@@ -24,7 +24,7 @@ import (
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ssh",
-		Short:   "SSH into a container",
+		Short:   "Opens a shell in a container.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/ssh/ssh_linux.go
+++ b/command/ssh/ssh_linux.go
@@ -25,7 +25,7 @@ import (
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ssh",
-		Short:   "SSH into a container",
+		Short:   "Opens a shell in a container.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/start/start.go
+++ b/command/start/start.go
@@ -26,7 +26,7 @@ const exampleText = `  # start all containers
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "start",
-		Short:   "Start containers",
+		Short:   "Starts containers.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/stop/stop.go
+++ b/command/stop/stop.go
@@ -30,7 +30,7 @@ const exampleText = `  # stop all containers
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "stop",
-		Short:   "Stop containers",
+		Short:   "Stops containers.",
 		Example: exampleText,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			cfg, err := config.Load(home)

--- a/command/trust/trust.go
+++ b/command/trust/trust.go
@@ -38,7 +38,7 @@ const (
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "trust",
-		Short:   "Trust certificates for environment",
+		Short:   "Trusts Nitro certificates on the host machine.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/command/update/update.go
+++ b/command/update/update.go
@@ -35,7 +35,7 @@ var (
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
-		Short: "Update nitro containers and proxy",
+		Short: "Updates Nitro containers and proxy.",
 		Example: `  # update nitro
   nitro update`,
 		PostRunE: func(cmd *cobra.Command, args []string) error {

--- a/command/validate/validate.go
+++ b/command/validate/validate.go
@@ -18,7 +18,7 @@ const exampleText = `  # validate a config file
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "validate",
-		Short:   "Validate the config",
+		Short:   "Validates the Nitro config file.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load(home)

--- a/command/version/version.go
+++ b/command/version/version.go
@@ -23,7 +23,7 @@ var exampleText = `nitro version`
 func NewCommand(home string, client client.CommonAPIClient, nitrod protob.NitroClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
-		Short:   "Show version info",
+		Short:   "Displays version info.",
 		Example: exampleText,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.VerifyInit(cmd, args, home, output)

--- a/command/xoff/xoff.go
+++ b/command/xoff/xoff.go
@@ -19,7 +19,7 @@ const exampleText = `  # example command
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "xoff",
-		Short:   "Disable xdebug for a site",
+		Short:   "Disables Xdebug for a site.",
 		Example: exampleText,
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.RunApply(cmd, args, false, output)

--- a/command/xon/xon.go
+++ b/command/xon/xon.go
@@ -20,7 +20,7 @@ const exampleText = `  # example command
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "xon",
-		Short:   "Enable xdebug for a site",
+		Short:   "Enables Xdebug for a site.",
 		Example: exampleText,
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.RunApply(cmd, args, false, output)


### PR DESCRIPTION
### Description

Updates Nitro’s short command descriptions for internal consistency, miscellaneous corrections, and consistency with Craft’s console commands.

- Capitalizes proper nouns like Blackfire and Xdebug.
- More accurately describes whether action applies to one or multiple things (`Runs Composer commands` → `Runs a Composer command`.)
- More specifically describes a handful of actions.
- Revises format to match Craft’s `Remove unused containers` → `Removes unused containers.`.
- Updates root command descriptions to align more with [getnitro.sh](https://getnitro.sh/) and [docs](https://craftcms.com/docs/nitro/2.x/).