### PR TITLE
add permissions command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docker docs
 
-VERSION ?= 2.0.6
+VERSION ?= 2.0.7
 
 build:
 	go build -trimpath -ldflags="-s -w -X 'github.com/craftcms/nitro/command/version.Version=${VERSION}'" -o nitro ./cmd/nitro

--- a/command/nitro/nitro.go
+++ b/command/nitro/nitro.go
@@ -29,6 +29,7 @@ import (
 	"github.com/craftcms/nitro/command/logs"
 	"github.com/craftcms/nitro/command/ls"
 	"github.com/craftcms/nitro/command/npm"
+	"github.com/craftcms/nitro/command/permissions"
 	"github.com/craftcms/nitro/command/php"
 	"github.com/craftcms/nitro/command/portcheck"
 	"github.com/craftcms/nitro/command/queue"
@@ -124,6 +125,7 @@ func NewCommand() *cobra.Command {
 		logs.NewCommand(home, docker, term),
 		ls.NewCommand(home, docker, term),
 		npm.NewCommand(docker, term),
+		permissions.NewCommand(home, docker, term),
 		php.NewCommand(home, docker, term),
 		portcheck.NewCommand(term),
 		queue.NewCommand(home, docker, term),

--- a/command/permissions/permissions.go
+++ b/command/permissions/permissions.go
@@ -1,0 +1,131 @@
+package permissions
+
+import (
+	"fmt"
+	"os/exec"
+	"os/user"
+	"runtime"
+
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+
+	"github.com/craftcms/nitro/pkg/config"
+	"github.com/craftcms/nitro/pkg/terminal"
+)
+
+type file struct {
+	path      string
+	directory bool
+}
+
+const exampleText = `  # fix file permissions for craft
+  nitro permissions`
+
+var files = []file{
+	{
+		path:      "/app/.env",
+		directory: false,
+	},
+	{
+		path:      "/app/composer.json",
+		directory: false,
+	},
+	{
+		path:      "/app/composer.lock",
+		directory: false,
+	},
+	{
+		path:      "/app/config/licence.key",
+		directory: false,
+	},
+	{
+		path:      "/app/config",
+		directory: true,
+	},
+	{
+		path:      "/app/config/project",
+		directory: true,
+	},
+	{
+		path:      "/app/storage",
+		directory: true,
+	},
+	{
+		path:      "/app/vendor",
+		directory: true,
+	},
+	{
+		path:      "/app/web/cpresources",
+		directory: true,
+	},
+}
+
+func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "permissions",
+		Short:   "Fixes Craft permissions.",
+		Example: exampleText,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			cfg, err := config.Load(home)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveDefault
+			}
+
+			var options []string
+			for _, s := range cfg.Sites {
+				options = append(options, s.Hostname)
+			}
+
+			return options, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// find the docker executable
+			cli, err := exec.LookPath("docker")
+			if err != nil {
+				return err
+			}
+
+			for _, f := range files {
+				stat, _ := docker.ContainerStatPath(ctx, "tutorial.nitro", f.path)
+
+				if stat.Name != "" {
+					fmt.Println("setting permissions on", f.path)
+
+					containerUser := "www-data"
+					if runtime.GOOS == "linux" {
+						user, err := user.Current()
+						if err != nil {
+							return err
+						}
+						containerUser = fmt.Sprintf("%s:%s", user.Uid, user.Gid)
+					}
+
+					cmds := []string{"exec", "-it", "--user", containerUser, "tutorial.nitro"}
+
+					if f.directory {
+						cmds = append(cmds, "chmod", "-R", "777", f.path)
+					} else {
+						cmds = append(cmds, "chmod", "777", f.path)
+					}
+
+					// create the command
+					c := exec.Command(cli, cmds...)
+
+					c.Stdin = cmd.InOrStdin()
+					c.Stderr = cmd.ErrOrStderr()
+					c.Stdout = cmd.OutOrStdout()
+
+					if err := c.Run(); err != nil {
+						fmt.Println("error setting permissions on", f.path)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/command/permissions/permissions.go
+++ b/command/permissions/permissions.go
@@ -151,7 +151,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				stat, _ := docker.ContainerStatPath(ctx, site.Hostname, f.path)
 
 				if stat.Name != "" {
-					fmt.Println("setting permissions on", f.path)
+					output.Pending("modifying", f.path)
 
 					containerUser := "www-data"
 					if runtime.GOOS == "linux" {
@@ -180,6 +180,8 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					if err := c.Run(); err != nil {
 						fmt.Println("error setting permissions on", f.path)
 					}
+
+					output.Done()
 				}
 			}
 

--- a/command/permissions/permissions.go
+++ b/command/permissions/permissions.go
@@ -185,6 +185,8 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				}
 			}
 
+			output.Info("Permssions modified on", site.Hostname, "🔓")
+
 			return nil
 		},
 	}


### PR DESCRIPTION
### Description

This command is to automatically set permissions on a Nitro Craft site. This applies to Linux users as Docker Desktop on macOS handles permissions.

### To Do

- [x] Make the permissions command accept a site argument and be "site aware"
- [ ] Add documentation for the command.



