### PR TITLE
Omit `...` from final database import output.

### DIFF
--- a/command/database/import.go
+++ b/command/database/import.go
@@ -334,7 +334,7 @@ func importCommand(home string, docker client.CommonAPIClient, nitrod protob.Nit
 
 			output.Done()
 
-			output.Info(fmt.Sprintf("%s, took %.2f seconds 💪...", reply.Message, time.Since(start).Seconds()))
+			output.Info(fmt.Sprintf("%s, took %.2f seconds 💪", reply.Message, time.Since(start).Seconds()))
 
 			return nil
 		},

--- a/command/database/import.go
+++ b/command/database/import.go
@@ -334,7 +334,7 @@ func importCommand(home string, docker client.CommonAPIClient, nitrod protob.Nit
 
 			output.Done()
 
-			output.Info(fmt.Sprintf("%s, took %.2f seconds 💪", reply.Message, time.Since(start).Seconds()))
+			output.Info(fmt.Sprintf("%s in %.2f seconds 💪", reply.Message, time.Since(start).Seconds()))
 
 			return nil
 		},


### PR DESCRIPTION
### Description

After successfully importing a database dump, Nitro reports where it went and how long it took:

```
$ nitro db import dump.sql
  … detecting backup type ✓
Detected postgres backup
Enter the database name: tutorial
Preparing import…
  … uploading backup dump.sql ✓
Imported database "tutorial", took 4.23 seconds 💪...
```

But the `💪...` feels like it’s saying “BUT...” or preparing to say/do something else when it is in fact finished.

This PR slightly shortens that message and lets us almost literally end strong:

```
$ nitro db import dump.sql
  … detecting backup type ✓
Detected postgres backup
Enter the database name: tutorial
Preparing import…
  … uploading backup dump.sql ✓
Imported database "tutorial" in 4.23 seconds 💪
```

