### PR TITLE
Add site argument for `remove` command

### DIFF
--- a/command/remove/remove.go
+++ b/command/remove/remove.go
@@ -92,7 +92,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				}
 			}
 
-			output.Info("Removing", sites[0].Hostname)
+			output.Info("Removing", site.Hostname)
 
 			// remove the site
 			if err := cfg.RemoveSite(site); err != nil {


### PR DESCRIPTION
### Description

This makes it possible to skip the site prompt by passing an argument to `nitro remove`, consistent with other site-specific commands in the upcoming release.

**Before**

Argument still shows site prompt:

```sh
❯ nitro remove test.nitro
Select a site:
  1. craftcms.nitro
  2. europa.nitro
  3. starterblog.nitro
  4. test.nitro
  5. tutorial.nitro
```

**After**

Argument skips questioning. 😎 

```sh
❯ nitro remove test.nitro
Removing test.nitro
```