### PR TITLE
Remove ellipsis from `nitro trust` output.

### DIFF
--- a/command/trust/trust.go
+++ b/command/trust/trust.go
@@ -68,7 +68,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			containerID := containers[0].ID
 
 			// get the contents of the certificate from the container
-			output.Pending("getting Nitro’s root site certificate…")
+			output.Pending("getting Nitro’s root site certificate")
 
 			// verify the file exists in the container
 			for {


### PR DESCRIPTION
### Description

Removes trailing ellipsis since resulting status is indicated with another character—this makes the output consistent with other commands.

**Before**

```
❯ nitro trust
  … getting Nitro’s root site certificate… ✓
```

**After**

```
❯ nitro trust
  … getting Nitro’s root site certificate ✓
```

