### PR TITLE
Add Elementary OS to certinstall conditional

### DIFF
--- a/pkg/certinstall/certinstall.go
+++ b/pkg/certinstall/certinstall.go
@@ -97,7 +97,7 @@ func identify(description string) (string, error) {
 	}
 
 	// detect debian systems
-	if strings.Contains(description, "Ubuntu") || strings.Contains(description, "Pop!_OS") || strings.Contains(description, "Mint") {
+	if strings.Contains(description, "Ubuntu") || strings.Contains(description, "Pop!_OS") || strings.Contains(description, "Mint") || strings.Contains(description, "elementary") {
 		return "debian", nil
 	}
 


### PR DESCRIPTION
### Description
Added a check for 'elementary' to the Debian distribution check conditional, let me know if you'd prefer if I added the full 'elementary OS' to avoid any potential conflicts!

### Related issues
#323
