### PR TITLE
alias command allows spaces in list of hostnames. Different validators for hostname and list of hostnames

### DIFF
--- a/command/alias/alias.go
+++ b/command/alias/alias.go
@@ -103,30 +103,27 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// prompt the user to add new alias
-			alias, err := output.Ask("Enter the alias domain for the site (use commas to enter multiple)", "", ":", &multipleHostnameValidator{})
+			v := validate.MultipleHostnameValidator{}
+			alias, err := output.Ask("Enter the alias domain for the site (use commas to enter multiple)", "", ":", &v)
 			if err != nil {
 				return err
 			}
 
-			if strings.Contains(alias, ",") {
-				parts := strings.Split(alias, ",")
+			parts, err := v.Parse(alias)
+			if err != nil {
+				return err
+			}
 
+			if len(parts) > 1 {
 				output.Info("Adding aliases:")
-
-				for _, a := range parts {
-					a = strings.TrimSpace(a)
-					output.Info("  ", a)
-
-					// set the alias
-					if err := cfg.SetSiteAlias(site.Hostname, a); err != nil {
-						return err
-					}
-				}
 			} else {
-				output.Info("Adding alias:", alias)
+				output.Info("Adding alias:")
+			}
+			for _, a := range parts {
+				output.Info("  ", a)
 
 				// set the alias
-				if err := cfg.SetSiteAlias(site.Hostname, alias); err != nil {
+				if err := cfg.SetSiteAlias(site.Hostname, a); err != nil {
 					return err
 				}
 			}
@@ -141,20 +138,4 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 	}
 
 	return cmd
-}
-
-// multipleHostnameValidator validates a comma separated list of hostnames
-type multipleHostnameValidator struct{}
-
-func (v *multipleHostnameValidator) Validate(input string) error {
-	hosts := strings.Split(input, ",")
-	hostV := &validate.HostnameValidator{}
-
-	for _, h := range hosts {
-		h := strings.TrimSpace(h)
-		if err := hostV.Validate(h); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/command/alias/alias.go
+++ b/command/alias/alias.go
@@ -103,7 +103,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// prompt the user to add new alias
-			alias, err := output.Ask("Enter the alias domain for the site (use commas to enter multiple)", "", ":", &validate.HostnameValidator{})
+			alias, err := output.Ask("Enter the alias domain for the site (use commas to enter multiple)", "", ":", &multipleHostnameValidator{})
 			if err != nil {
 				return err
 			}
@@ -114,6 +114,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				output.Info("Adding aliases:")
 
 				for _, a := range parts {
+					a = strings.TrimSpace(a)
 					output.Info("  ", a)
 
 					// set the alias
@@ -140,4 +141,20 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 	}
 
 	return cmd
+}
+
+// multipleHostnameValidator validates a comma separated list of hostnames
+type multipleHostnameValidator struct{}
+
+func (v *multipleHostnameValidator) Validate(input string) error {
+	hosts := strings.Split(input, ",")
+	hostV := &validate.HostnameValidator{}
+
+	for _, h := range hosts {
+		h := strings.TrimSpace(h)
+		if err := hostV.Validate(h); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -55,6 +55,29 @@ func (v *HostnameValidator) Validate(input string) error {
 	return nil
 }
 
+// MultipleHostnameValidator validates a comma separated list of hostnames
+type MultipleHostnameValidator struct{}
+
+func (v *MultipleHostnameValidator) Validate(input string) error {
+	_, err := v.Parse(input)
+	return err
+}
+
+func (v *MultipleHostnameValidator) Parse(input string) ([]string, error) {
+	rawHosts := strings.Split(input, ",")
+	hostV := &HostnameValidator{}
+	var hosts []string
+
+	for _, h := range rawHosts {
+		h := strings.TrimSpace(h)
+		if err := hostV.Validate(h); err != nil {
+			return nil, err
+		}
+		hosts = append(hosts, h)
+	}
+	return hosts, nil
+}
+
 type PHPVersionValidator struct{}
 
 func (v *PHPVersionValidator) Validate(input string) error {
@@ -82,8 +105,7 @@ func (v *IsMegabyte) Validate(input string) error {
 	return isMegabytes(input)
 }
 
-type MaxExecutionTime struct {
-}
+type MaxExecutionTime struct{}
 
 func (v *MaxExecutionTime) Validate(input string) error {
 	return maxExecutionTime(input)

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -48,7 +48,7 @@ func (v *HostnameValidator) Validate(input string) error {
 	}
 
 	// check for special characters
-	if strings.ContainsAny(input, "!@#$%^&*()") {
+	if strings.ContainsAny(input, "!@#$%^&*(),") {
 		return fmt.Errorf("hostname must not include any special characters")
 	}
 
@@ -63,7 +63,7 @@ func (v *PHPVersionValidator) Validate(input string) error {
 		return nil
 	}
 
-	return fmt.Errorf("the PHP inputrsion %q is not valid", input)
+	return fmt.Errorf("the PHP version %q is not valid", input)
 }
 
 type IsBoolean struct{}

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -44,7 +44,7 @@ func TestHostnameValidator_Validate(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "valide hostnames do not return an err",
+			name: "valid hostnames do not return an err",
 			args: args{
 				input: "validhostname.tld",
 			},
@@ -68,6 +68,13 @@ func TestHostnameValidator_Validate(t *testing.T) {
 			name: "less than 3 chars returns an err",
 			args: args{
 				input: "12",
+			},
+			wantErr: true,
+		},
+		{
+			name: "comma separated list returns an err",
+			args: args{
+				input: "host1.tld,host.tld",
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
### Description
Same `validate.HostnameValidator` was used for comma separated list of hostnames (alias) and for single hostnames.

Factored out the validator for the list of hostnames, and made it slightly more forgiving, so that `this.tld, that.dld` is a valid list. Added `,` to the disallowed special characters of the HostnameValidator

Fixed two minor typos

