### PR TITLE
`webroot` → `web root`

### DIFF
--- a/command/apply/internal/match/match.go
+++ b/command/apply/internal/match/match.go
@@ -77,7 +77,7 @@ func Site(home string, site config.Site, container types.ContainerJSON, blackfir
 		return false
 	}
 
-	// check the webroot is defined and they match
+	// check the web root is defined and they match
 	if container.Config.Labels[containerlabels.Webroot] != site.Webroot {
 		return false
 	}

--- a/command/apply/internal/match/match_test.go
+++ b/command/apply/internal/match/match_test.go
@@ -256,7 +256,7 @@ func TestSite(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "containers without webroot label returns false",
+			name: "containers without web root label returns false",
 			args: args{
 				home: "testdata/example-site",
 				site: config.Site{
@@ -282,7 +282,7 @@ func TestSite(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "mismatched webroot returns false",
+			name: "mismatched web root returns false",
 			args: args{
 				home: "testdata/example-site",
 				site: config.Site{

--- a/command/context/context.go
+++ b/command/context/context.go
@@ -47,7 +47,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					output.Info("  aliases:\t", strings.Join(site.Aliases, ", "))
 				}
 				output.Info("  php:\t", site.Version)
-				output.Info("  webroot:\t", site.Webroot)
+				output.Info("  web root:\t", site.Webroot)
 				output.Info("  path:\t", site.Path)
 				output.Info("  ---")
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -227,7 +227,7 @@ func (s *Site) GetAbsPath(home string) (string, error) {
 }
 
 // GetContainerPath is responsible for looking at the
-// sites webroot and determing the correct path in the
+// site’s web root and determing the correct path in the
 // container. This is used for the craft and queue
 // commands to identify the location of the "craft"
 // executable.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1010,7 +1010,7 @@ func TestSite_GetContainerPath(t *testing.T) {
 			want: "another-site",
 		},
 		{
-			name: "default webroots with a trailing slash return the correct value",
+			name: "default web roots with a trailing slash return the correct value",
 			fields: fields{
 				Webroot: "web/",
 			},

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -249,18 +249,18 @@ func CreateSite(home, dir string, output terminal.Outputer) (*config.Site, error
 		found = "web"
 	}
 
-	// set the webroot
+	// set the web root
 	site.Webroot = found
 
-	// prompt for the webroot
-	root, err := output.Ask("Enter the webroot for the site", site.Webroot, ":", nil)
+	// prompt for the web root
+	root, err := output.Ask("Enter the web root for the site", site.Webroot, ":", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	site.Webroot = root
 
-	output.Success("using webroot", site.Webroot)
+	output.Success("using web root", site.Webroot)
 
 	// prompt for the php version
 	versions := phpversions.Versions

--- a/pkg/webroot/webroot.go
+++ b/pkg/webroot/webroot.go
@@ -8,14 +8,14 @@ import (
 )
 
 var (
-	// ErrNotFound is returned when unable to find a webroot for a specified path
-	ErrNotFound = fmt.Errorf("unable to locate a webroot")
+	// ErrNotFound is returned when unable to find a web root for a specified path
+	ErrNotFound = fmt.Errorf("unable to locate a web root")
 )
 
-// Find takes a path and will check for the webroot of the
+// Find takes a path and will check for the web root of the
 // project. Find will look for web, public, and public_html
 // directories and return when the first directory match.
-// If it cannot find the webroot it will return an error.
+// If it cannot find the web root it will return an error.
 func Find(path string) (string, error) {
 	var root string
 	if err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {

--- a/pkg/webroot/webroot_test.go
+++ b/pkg/webroot/webroot_test.go
@@ -16,7 +16,7 @@ func TestFind(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "find the webroot",
+			name: "find the web root",
 			args: args{
 				path: filepath.Join("testdata", "no-vendor"),
 			},


### PR DESCRIPTION
### Description

We aspire to always write “web root” as two words. This intriguing PR separates them out in strings and comments without modifying variable names that’d result in a breaking change.