### PR TITLE
Reduce unarchive verbosity during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,7 @@ function getNitro {
   if [ "$?" = "0" ]; then
 
     # unzip
-    tar xvzf "$targetZipFile" -C "$targetTempFolder"
+    tar xzf "$targetZipFile" -C "$targetTempFolder"
 
     # verify
     checkHash "$targetZipFile" "$version" "$targetTempFolder" "$fileName"


### PR DESCRIPTION
### Description

If someone runs the Nitro one-line Bash installer, the output starts with this:

```
$ bash <(curl -sLS http://installer.getnitro.sh)
Downloading package https://github.com/craftcms/nitro/releases/download/2.0.7/nitro_darwin_x86_64.tar.gz to /Users/oli/temp_nitro_extract/nitro_darwin_x86_64.tar.gz

x CHANGELOG.md
x LICENSE.md
x README.md
x nitro

Download complete.

Running with sufficient permissions to attempt to move nitro to /usr/local/bin

(... things continue to happen ...)
```

Lines like these almost look like something erroneous happened:

```
x CHANGELOG.md
```

They appear because of `tar`’s `v` flag which includes verbose output.

From [the man page](https://man7.org/linux/man-pages/man1/tar.1.html):

>       -v, --verbose
>           Verbosely list files processed.  Each instance of this
>           option on the command line increases the verbosity level
>           by one.  The maximum verbosity level is 3.  For a detailed
>           discussion of how various verbosity levels affect tar's
>           output, please refer to GNU Tar Manual, subsection 2.5.1
>           "The --verbose Option".

Since it looks somewhat alarming right from the start and doesn’t provide anything meaningful to the user, this PR boldly omits the `v` flag for a friendlier first impression.

```
$ bash <(curl -sLS http://installer.getnitro.sh)
Downloading package https://github.com/craftcms/nitro/releases/download/2.0.7/nitro_darwin_x86_64.tar.gz to /Users/oli/temp_nitro_extract/nitro_darwin_x86_64.tar.gz

Download complete.

Running with sufficient permissions to attempt to move nitro to /usr/local/bin

(... things continue to happen ...)
```