### PR TITLE
Improve output

### DIFF
--- a/command/apply/apply.go
+++ b/command/apply/apply.go
@@ -314,7 +314,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 			// check dynamodb service
 			switch cfg.Services.DynamoDB {
 			case false:
-				output.Pending("checking dynamodb service")
+				output.Pending("checking dynamodb")
 
 				if err := dynamodb.VerifyRemoved(ctx, docker, output); err != nil {
 					output.Warning()
@@ -323,7 +323,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 
 				output.Done()
 			default:
-				output.Pending("checking dynamodb service")
+				output.Pending("checking dynamodb")
 
 				_, hostname, err := dynamodb.VerifyCreated(ctx, docker, network.ID, output)
 				if err != nil {
@@ -340,7 +340,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 			// check mailhog service
 			switch cfg.Services.Mailhog {
 			case false:
-				output.Pending("checking mailhog service")
+				output.Pending("checking mailhog")
 
 				// make sure the service container is removed
 				if err := mailhog.VerifyRemoved(ctx, docker, output); err != nil {
@@ -349,7 +349,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 
 				output.Done()
 			default:
-				output.Pending("checking mailhog service")
+				output.Pending("checking mailhog")
 
 				// verify the mailhog container is created
 				_, hostname, err := mailhog.VerifyCreated(ctx, docker, network.ID, output)
@@ -373,7 +373,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 					return err
 				}
 			default:
-				output.Pending("checking minio service")
+				output.Pending("checking minio")
 
 				// verify the minio container is created
 				_, hostname, err := minio.VerifyCreated(ctx, docker, network.ID, output)
@@ -391,7 +391,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 			// check redis service
 			switch cfg.Services.Redis {
 			case false:
-				output.Pending("checking redis service")
+				output.Pending("checking redis")
 
 				if err := redis.VerifyRemoved(ctx, docker, output); err != nil {
 					return err
@@ -399,7 +399,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 
 				output.Done()
 			default:
-				output.Pending("checking redis service")
+				output.Pending("checking redis")
 
 				_, hostname, err := redis.VerifyCreated(ctx, docker, network.ID, output)
 				if err != nil {

--- a/command/apply/apply.go
+++ b/command/apply/apply.go
@@ -128,7 +128,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 			}
 
 			if len(containers) > 0 {
-				output.Info("Cleaning up...")
+				output.Info("Cleaning up…")
 			}
 
 			for _, c := range containers {

--- a/command/apply/apply.go
+++ b/command/apply/apply.go
@@ -415,7 +415,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 
 			if len(cfg.Containers) > 0 {
 				// get all of the containers
-				output.Info("Checking containers...")
+				output.Info("Checking containers…")
 
 				for _, c := range cfg.Containers {
 					output.Pending("checking", fmt.Sprintf("%s.containers.nitro", c.Name))

--- a/command/blackfire/off.go
+++ b/command/blackfire/off.go
@@ -111,7 +111,7 @@ func offCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 					site = &sites[selected]
 				case 1:
-					output.Info("Enabling Blackfire for", sites[0].Hostname)
+					output.Info("Disabling Blackfire for", sites[0].Hostname)
 
 					site = &sites[0]
 				default:

--- a/command/container/new.go
+++ b/command/container/new.go
@@ -78,7 +78,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			image := images[selection].Name
 
 			// ask for the tag (default to latest)
-			tag, err := output.Ask("What tag should we use", "latest", "?", nil)
+			tag, err := output.Ask("What tag should we use?", "latest", "", nil)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				}
 
 				// should we prompt for the port to be exposed?
-				add, err := output.Confirm(fmt.Sprintf("Expose port `%s` on host", p), true, "?")
+				add, err := output.Confirm(fmt.Sprintf("Expose port `%s` on host?", p), true, "")
 				if err != nil {
 					return err
 				}
@@ -136,7 +136,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				}
 			}
 
-			exposesUI, err := output.Confirm("Does the image contain a web-based UI", true, "?")
+			exposesUI, err := output.Confirm("Does the image contain a web-based UI?", true, "")
 			if err != nil {
 				return err
 			}
@@ -190,7 +190,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			var volumes []string
 			for v := range imageSpecs.ContainerConfig.Volumes {
 				// should we create a volume for the volume?
-				add, err := output.Confirm(fmt.Sprintf("Create volume `%q` for container", v), true, "?")
+				add, err := output.Confirm(fmt.Sprintf("Create volume `%q` for container?", v), true, "")
 				if err != nil {
 					return err
 				}
@@ -207,7 +207,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// prompt for the container name
-			name, err := output.Ask("What is the name of the container", suggested, "?", &validate.HostnameValidator{})
+			name, err := output.Ask("What is the name of the container?", suggested, "", &validate.HostnameValidator{})
 			if err != nil {
 				return err
 			}
@@ -223,7 +223,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// setup a custom env file?
-			createEnvfile, err := output.Confirm("Create a file to add environment variables", true, "?")
+			createEnvfile, err := output.Confirm("Create a file to add environment variables?", true, "")
 			if err != nil {
 				return err
 			}

--- a/command/database/add.go
+++ b/command/database/add.go
@@ -107,13 +107,13 @@ func addCommand(docker client.CommonAPIClient, nitrod protob.NitroClient, output
 				output.Warning()
 
 				// ask if the update command should run
-				confirm, err := output.Confirm("The API does not appear to be updated, run `nitro update` now", true, "?")
+				confirm, err := output.Confirm("The API does not appear to be updated. Run `nitro update` now?", true, "")
 				if err != nil {
 					return err
 				}
 
 				if !confirm {
-					output.Info("Skipping the update command, you need to update before using this command")
+					output.Info("Skipping the update command; you need to update before using this command.")
 
 					return nil
 				}

--- a/command/database/import.go
+++ b/command/database/import.go
@@ -216,13 +216,13 @@ func importCommand(home string, docker client.CommonAPIClient, nitrod protob.Nit
 				output.Warning()
 
 				// ask if the update command should run
-				confirm, err := output.Confirm("The API does not appear to be updated, run `nitro update` now", true, "?")
+				confirm, err := output.Confirm("The API does not appear to be updated. Run `nitro update` now?", true, "")
 				if err != nil {
 					return err
 				}
 
 				if !confirm {
-					output.Info("Skipping the update command, you need to update before using this command")
+					output.Info("Skipping the update command; you need to update before using this command.")
 
 					return nil
 				}
@@ -260,13 +260,13 @@ func importCommand(home string, docker client.CommonAPIClient, nitrod protob.Nit
 				output.Warning()
 
 				// ask if the update command should run
-				confirm, err := output.Confirm("The API does not appear to be updated, run `nitro update` now", true, "?")
+				confirm, err := output.Confirm("The API does not appear to be updated. Run `nitro update` now?", true, "")
 				if err != nil {
 					return err
 				}
 
 				if !confirm {
-					output.Info("Skipping the update command, you need to update before using this command")
+					output.Info("Skipping the update command; you need to update before using this command.")
 
 					return nil
 				}

--- a/command/database/new.go
+++ b/command/database/new.go
@@ -43,7 +43,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// prompt for the engine
-			selection, err := output.Select(cmd.InOrStdin(), "Which database engine should we use", options)
+			selection, err := output.Select(cmd.InOrStdin(), "Which database engine should we use?", options)
 			if err != nil {
 				return err
 			}

--- a/command/database/new.go
+++ b/command/database/new.go
@@ -52,7 +52,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			engine := options[selection]
 
 			// ask for the version
-			version, err := output.Ask("Which version should we use", "", "?", nil)
+			version, err := output.Ask("Which version should we use?", "", "", nil)
 			if err != nil {
 				return err
 			}
@@ -73,7 +73,7 @@ func newCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// confirm the port to use
-			port, err := output.Ask("Which port should we use for "+engine, p, "?", nil)
+			port, err := output.Ask("Which port should we use for "+engine+"?", p, "", nil)
 			if err != nil {
 				return err
 			}

--- a/command/database/remove.go
+++ b/command/database/remove.go
@@ -115,13 +115,13 @@ func removeCommand(docker client.CommonAPIClient, nitrod protob.NitroClient, out
 				output.Warning()
 
 				// ask if the update command should run
-				confirm, err := output.Confirm("The API does not appear to be updated, run `nitro update` now", true, "?")
+				confirm, err := output.Confirm("The API does not appear to be updated. Run `nitro update` now?", true, "")
 				if err != nil {
 					return err
 				}
 
 				if !confirm {
-					output.Info("Skipping the update command, you need to update before using this command")
+					output.Info("Skipping the update command; you need to update before using this command.")
 
 					return nil
 				}

--- a/command/destroy/destroy.go
+++ b/command/destroy/destroy.go
@@ -52,7 +52,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			}
 
 			// prompt the user for confirmation
-			confirm, err := output.Confirm("Are you sure (this will remove all containers, volumes, and networks)", false, "")
+			confirm, err := output.Confirm("Are you sure? (This will remove all containers, volumes, and networks.)", false, "")
 			if err != nil {
 				return err
 			}

--- a/command/destroy/destroy.go
+++ b/command/destroy/destroy.go
@@ -184,7 +184,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			// get all the volumes
 			if len(volumes.Volumes) > 0 {
-				output.Info("Removing Volumes…")
+				output.Info("Removing volumes…")
 
 				for _, v := range volumes.Volumes {
 					output.Pending("removing", v.Name)

--- a/command/iniset/iniset.go
+++ b/command/iniset/iniset.go
@@ -169,7 +169,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			// prompt the user for the setting to change
 			switch setting {
 			case "display_errors":
-				value, err := output.Ask("Should we display PHP errors", "true", "?", &validate.IsBoolean{})
+				value, err := output.Ask("Should we display PHP errors?", "true", "", &validate.IsBoolean{})
 				if err != nil {
 					return err
 				}
@@ -185,7 +185,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "max_execution_time":
-				value, err := output.Ask("What should the max execution time be", config.DefaultEnvs["PHP_MAX_EXECUTION_TIME"], "?", &validate.MaxExecutionTime{})
+				value, err := output.Ask("What should the max execution time be?", config.DefaultEnvs["PHP_MAX_EXECUTION_TIME"], "", &validate.MaxExecutionTime{})
 				if err != nil {
 					return err
 				}
@@ -200,7 +200,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "max_input_vars":
-				value, err := output.Ask("What should the max input vars be", config.DefaultEnvs["PHP_MAX_INPUT_VARS"], "?", &validate.MaxExecutionTime{})
+				value, err := output.Ask("What should the max input vars be?", config.DefaultEnvs["PHP_MAX_INPUT_VARS"], "", &validate.MaxExecutionTime{})
 				if err != nil {
 					return err
 				}
@@ -215,7 +215,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "max_input_time":
-				value, err := output.Ask("What should the max input time be", config.DefaultEnvs["PHP_MAX_INPUT_TIME"], "?", &validate.MaxExecutionTime{})
+				value, err := output.Ask("What should the max input time be?", config.DefaultEnvs["PHP_MAX_INPUT_TIME"], "", &validate.MaxExecutionTime{})
 				if err != nil {
 					return err
 				}
@@ -230,7 +230,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "max_file_upload":
-				value, err := output.Ask("What should the new max file upload be", config.DefaultEnvs["PHP_UPLOAD_MAX_FILESIZE"], "?", &validate.IsMegabyte{})
+				value, err := output.Ask("What should the new max file upload be?", config.DefaultEnvs["PHP_UPLOAD_MAX_FILESIZE"], "", &validate.IsMegabyte{})
 				if err != nil {
 					return err
 				}
@@ -240,7 +240,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "memory_limit":
-				value, err := output.Ask("What should the new memory limit be", config.DefaultEnvs["PHP_MEMORY_LIMIT"], "?", &validate.IsMegabyte{})
+				value, err := output.Ask("What should the new memory limit be?", config.DefaultEnvs["PHP_MEMORY_LIMIT"], "", &validate.IsMegabyte{})
 				if err != nil {
 					return err
 				}
@@ -250,7 +250,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "opcache_enable":
-				value, err := output.Ask("Should we enable OPcache", "false", "?", &validate.IsBoolean{})
+				value, err := output.Ask("Should we enable OPcache?", "false", "", &validate.IsBoolean{})
 				if err != nil {
 					return err
 				}
@@ -266,7 +266,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "opcache_validate_timestamps":
-				value, err := output.Ask("Should we validate timestamps with OPcache", "false", "?", &validate.IsBoolean{})
+				value, err := output.Ask("Should we validate timestamps with OPcache?", "false", "", &validate.IsBoolean{})
 				if err != nil {
 					return err
 				}
@@ -282,7 +282,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "opcache_revalidate_freq":
-				value, err := output.Ask("What should the OPcache revalidate frequency be", config.DefaultEnvs["PHP_OPCACHE_REVALIDATE_FREQ"], "?", &validate.MaxExecutionTime{})
+				value, err := output.Ask("What should the OPcache revalidate frequency be?", config.DefaultEnvs["PHP_OPCACHE_REVALIDATE_FREQ"], "", &validate.MaxExecutionTime{})
 				if err != nil {
 					return err
 				}
@@ -297,7 +297,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "post_max_size":
-				value, err := output.Ask("What should post max size be", config.DefaultEnvs["PHP_POST_MAX_SIZE"], "?", &validate.IsMegabyte{})
+				value, err := output.Ask("What should post max size be?", config.DefaultEnvs["PHP_POST_MAX_SIZE"], "", &validate.IsMegabyte{})
 				if err != nil {
 					return err
 				}
@@ -307,7 +307,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 			case "upload_max_file_size":
-				value, err := output.Ask("What should upload maximum file size be", config.DefaultEnvs["PHP_UPLOAD_MAX_FILESIZE"], "?", &validate.IsMegabyte{})
+				value, err := output.Ask("What should upload maximum file size be?", config.DefaultEnvs["PHP_UPLOAD_MAX_FILESIZE"], "", &validate.IsMegabyte{})
 				if err != nil {
 					return err
 				}

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -24,7 +24,7 @@ import (
 // CreateDatabase is used to interactively walk a user through creating a new database. It will return true if the user created a database along
 // with the hostname, database, port, and driver for the database container.
 func CreateDatabase(cmd *cobra.Command, docker client.CommonAPIClient, output terminal.Outputer) (bool, string, string, string, string, error) {
-	confirm, err := output.Confirm("Add a database for the site", true, "")
+	confirm, err := output.Confirm("Add a database for the site?", true, "")
 	if err != nil {
 		return false, "", "", "", "", err
 	}
@@ -298,7 +298,7 @@ func CreateSite(home, dir string, output terminal.Outputer) (*config.Site, error
 func RunApply(cmd *cobra.Command, args []string, force bool, output terminal.Outputer) error {
 	if !force {
 		// ask if the apply command should run
-		apply, err := output.Confirm("Apply changes now", true, "?")
+		apply, err := output.Confirm("Apply changes now?", true, "")
 		if err != nil {
 			return err
 		}
@@ -334,14 +334,14 @@ func VerifyInit(cmd *cobra.Command, args []string, home string, output terminal.
 		output.Info("Warning:", err.Error())
 
 		// ask if the init command should run
-		init, err := output.Confirm("Run `nitro init` now to create the config", true, "?")
+		init, err := output.Confirm("Run `nitro init` now to create the config?", true, "")
 		if err != nil {
 			return err
 		}
 
 		// if init is false return nil
 		if !init {
-			return fmt.Errorf("You must run `nitro init` in order to add a site...")
+			return fmt.Errorf("You must run `nitro init` in order to add a site.")
 		}
 
 		// run the init command

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -35,7 +35,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 			output.Info("ARM computers do not work with mysql images at this time...")
 		}
 
-		mariadb, err := output.Confirm("Would you like to use MariaDB", true, "?")
+		mariadb, err := output.Confirm("Would you like to use MariaDB?", true, "")
 		if err != nil {
 			return err
 		}
@@ -43,7 +43,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 		if mariadb {
 			// prompt for the version
 			opts := []string{"10.5", "10.4", "10.3", "10.2", "10.1", "10"}
-			selected, err := output.Select(os.Stdin, "Select the version of MariaDB ", opts)
+			selected, err := output.Select(os.Stdin, "Select MariaDB version: ", opts)
 			if err != nil {
 				return err
 			}
@@ -71,7 +71,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 			})
 		}
 	default:
-		mysql, err := output.Confirm("Would you like to use MySQL", true, "?")
+		mysql, err := output.Confirm("Would you like to use MySQL?", true, "")
 		if err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 		if mysql {
 			// prompt for the version
 			opts := []string{"8.0", "5.7", "5.6"}
-			selected, err := output.Select(os.Stdin, "Select the version of MySQL ", opts)
+			selected, err := output.Select(os.Stdin, "Select MySQL version: ", opts)
 			if err != nil {
 				return err
 			}
@@ -108,7 +108,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 		}
 	}
 
-	postgres, err := output.Confirm("Would you like to use PostgreSQL", true, "?")
+	postgres, err := output.Confirm("Would you like to use PostgreSQL?", true, "")
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 	if postgres {
 		// prompt for the version
 		opts := []string{"13", "12", "11", "10", "9"}
-		selected, err := output.Select(os.Stdin, "Select the version of PostgreSQL ", opts)
+		selected, err := output.Select(os.Stdin, "Select PostgreSQL version: ", opts)
 		if err != nil {
 			return err
 		}
@@ -144,7 +144,7 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 		})
 	}
 
-	redis, err := output.Confirm("Would you like to use Redis", true, "?")
+	redis, err := output.Confirm("Would you like to use Redis?", true, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -30,9 +30,9 @@ func FirstTime(home string, reader io.Reader, output terminal.Outputer) error {
 	switch runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
 	case true:
 		if runtime.GOOS == "darwin" {
-			output.Info("Apple computers with new silicon do not work with mysql images at this time...")
+			output.Info("Apple computers with new silicon do not work with MySQL images.")
 		} else {
-			output.Info("ARM computers do not work with mysql images at this time...")
+			output.Info("ARM computers do not work with MySQL images.")
 		}
 
 		mariadb, err := output.Confirm("Would you like to use MariaDB?", true, "")

--- a/pkg/terminal/terminal.go
+++ b/pkg/terminal/terminal.go
@@ -194,7 +194,7 @@ func (t terminal) Select(r io.Reader, msg string, opts []string) (int, error) {
 		s, err := strconv.Atoi(char)
 		if err != nil || len(opts) < s {
 			wait = true
-			fmt.Println("Please choose a valid option…")
+			fmt.Println("Please choose a valid option:")
 
 			for k, v := range opts {
 				fmt.Printf("  %d. %s\n", k+1, v)


### PR DESCRIPTION
### Description

This makes several nitpicky changes to improve the clarity and consistency of some output.

- Replaces a few `...` with `…` characters for consistency.
- Prunes redundant or unnecessary words in various places.
- Fixes Blackfire “enabling” output that should be “disabling”.
- Adds a few question marks for questions, periods to finish complete statements (instead of `...`), and uses `:` for prompts that immediately list options afterward.
- Fixes several prompts to consistently display any fallback/suggestion after the complete question. (`Do a thing [Y/n]?` → `Do a thing? [Y\n]`)

Verbose, atomic commits detail each item for maximum fun.