### PR TITLE
upgrade image from buster to bullseye

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG IMAGE_USER
 ENV IMAGE_USER=${IMAGE_USER}


### PR DESCRIPTION
### Description

Upgrades the `craftcms/nitro` images from buster to the new bullseye release of Debian.

