### PR TITLE
Feature/adding enable blackfire command

### DIFF
--- a/command/apply/apply.go
+++ b/command/apply/apply.go
@@ -98,6 +98,11 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 				names[h] = true
 			}
 
+			// is blackfire enabled
+			if cfg.Services.Blackfire {
+				names[blackfire.Host] = true
+			}
+
 			// is dynamodb enabled
 			if cfg.Services.DynamoDB {
 				names[dynamodb.Host] = true

--- a/command/apply/internal/sitecontainer/sitecontainer.go
+++ b/command/apply/internal/sitecontainer/sitecontainer.go
@@ -134,9 +134,16 @@ func create(ctx context.Context, docker client.CommonAPIClient, home, networkID 
 
 	// does the config have blackfire credentials
 	if site.Blackfire {
-		// TODO(jasonmccallister) get the client id
-		envs = append(envs, "BLACKFIRE_CLIENT_ID=")
-		envs = append(envs, "BLACKFIRE_CLIENT_TOKEN=")
+		// grab the credentials from the config
+		credentials, err := cfg.GetBlackfireClientCredentials()
+		if err != nil {
+			return "", err
+		}
+
+		// add the client credentials
+		envs = append(envs, credentials...)
+
+		// set the agent socket to use the service container
 		envs = append(envs, "BLACKFIRE_AGENT_SOCKET=tcp://blackfire.service.nitro:8307")
 	}
 

--- a/command/apply/internal/sitecontainer/sitecontainer.go
+++ b/command/apply/internal/sitecontainer/sitecontainer.go
@@ -133,12 +133,11 @@ func create(ctx context.Context, docker client.CommonAPIClient, home, networkID 
 	envs := site.AsEnvs("host.docker.internal")
 
 	// does the config have blackfire credentials
-	if cfg.Blackfire.ServerID != "" {
-		envs = append(envs, "BLACKFIRE_SERVER_ID="+cfg.Blackfire.ServerID)
-	}
-
-	if cfg.Blackfire.ServerToken != "" {
-		envs = append(envs, "BLACKFIRE_SERVER_TOKEN="+cfg.Blackfire.ServerToken)
+	if site.Blackfire {
+		// TODO(jasonmccallister) get the client id
+		envs = append(envs, "BLACKFIRE_CLIENT_ID=")
+		envs = append(envs, "BLACKFIRE_CLIENT_TOKEN=")
+		envs = append(envs, "BLACKFIRE_AGENT_SOCKET=tcp://blackfire.service.nitro:8307")
 	}
 
 	// look for an existing volume with the sites hostname, otherwise create it

--- a/command/blackfire/on.go
+++ b/command/blackfire/on.go
@@ -78,6 +78,38 @@ func onCommand(home string, docker client.CommonAPIClient, output terminal.Outpu
 				}
 			}
 
+			// ensure the blackfire credentials are set
+			if cfg.Blackfire.ClientID == "" {
+				// ask for the server token
+				token, err := output.Ask("Enter your Blackfire Client ID", "", ":", nil)
+				if err != nil {
+					return err
+				}
+
+				cfg.Blackfire.ClientID = token
+
+				// save the config file
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("unable to save config, %w", err)
+				}
+			}
+
+			// ensure the blackfire credentials are set
+			if cfg.Blackfire.ClientToken == "" {
+				// ask for the server token
+				token, err := output.Ask("Enter your Blackfire Client Token", "", ":", nil)
+				if err != nil {
+					return err
+				}
+
+				cfg.Blackfire.ClientToken = token
+
+				// save the config file
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("unable to save config, %w", err)
+				}
+			}
+
 			// get the current working directory
 			wd, err := os.Getwd()
 			if err != nil {

--- a/command/enable/enable.go
+++ b/command/enable/enable.go
@@ -57,6 +57,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			// enable the service
 			switch args[0] {
 			case "blackfire":
+				// TODO(jasonmccallister) verify the credentials are set
 				cfg.Services.Blackfire = true
 			case "dynamodb":
 				cfg.Services.DynamoDB = true

--- a/command/enable/enable.go
+++ b/command/enable/enable.go
@@ -45,7 +45,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			return nil
 		},
-		ValidArgs: []string{"dynamodb", "mailhog", "minio", "redis"},
+		ValidArgs: []string{"blackfire", "dynamodb", "mailhog", "minio", "redis"},
 		Example:   exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// load the configuration
@@ -56,6 +56,8 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			// enable the service
 			switch args[0] {
+			case "blackfire":
+				cfg.Services.Blackfire = true
 			case "dynamodb":
 				cfg.Services.DynamoDB = true
 			case "mailhog":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -209,6 +209,10 @@ func (c *Config) AddContainer(container Container) error {
 func (c *Config) GetBlackfireCredentials() ([]string, error) {
 	var envs []string
 
+	if c.Blackfire.ServerID == "" || c.Blackfire.ServerToken == "" {
+		return nil, fmt.Errorf("no blackfire credentials provided")
+	}
+
 	envs = append(envs, "BLACKFIRE_SERVER_ID="+c.Blackfire.ServerID)
 	envs = append(envs, "BLACKFIRE_SERVER_TOKEN="+c.Blackfire.ServerToken)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,6 +204,17 @@ func (c *Config) AddContainer(container Container) error {
 	return nil
 }
 
+// GetBlackfireCredentials is used to return the blackfire credentials from
+// the config
+func (c *Config) GetBlackfireCredentials() ([]string, error) {
+	var envs []string
+
+	envs = append(envs, "BLACKFIRE_SERVER_ID="+c.Blackfire.ServerID)
+	envs = append(envs, "BLACKFIRE_SERVER_TOKEN="+c.Blackfire.ServerToken)
+
+	return envs, nil
+}
+
 // Database is the struct used to represent a database engine
 // that is a combination of a engine (e.g. mariadb, mysql, or
 // postgres), the version number, and the port. The engine
@@ -231,10 +242,11 @@ func (d *Database) GetHostname() (string, error) {
 // networking options for these types of services. We plan to support "custom" container options to make local users
 // development even better.
 type Services struct {
-	DynamoDB bool `json:"dynamodb"`
-	Mailhog  bool `json:"mailhog"`
-	Minio    bool `json:"minio"`
-	Redis    bool `json:"redis"`
+	Blackfire bool `json:"blackfire"`
+	DynamoDB  bool `json:"dynamodb"`
+	Mailhog   bool `json:"mailhog"`
+	Minio     bool `json:"minio"`
+	Redis     bool `json:"redis"`
 }
 
 // Site represents a web application. It has a hostname, aliases (which

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,8 @@ func (c *Config) ListOfSitesByDirectory(home, wd string) []Site {
 
 // Blackfire allows users to setup their containers to use blackfire locally.
 type Blackfire struct {
+	ClientID    string `json:"client_id,omitempty" yaml:"client_id,omitempty"`
+	ClientToken string `json:"client_token,omitempty" yaml:"client_token,omitempty"`
 	ServerID    string `json:"server_id,omitempty" yaml:"server_id,omitempty"`
 	ServerToken string `json:"server_token,omitempty" yaml:"server_token,omitempty"`
 }
@@ -204,9 +206,24 @@ func (c *Config) AddContainer(container Container) error {
 	return nil
 }
 
-// GetBlackfireCredentials is used to return the blackfire credentials from
+// GetBlackfireClientCredentials is used to return the blackfire credentials from
 // the config
-func (c *Config) GetBlackfireCredentials() ([]string, error) {
+func (c *Config) GetBlackfireClientCredentials() ([]string, error) {
+	var envs []string
+
+	if c.Blackfire.ClientID == "" || c.Blackfire.ClientToken == "" {
+		return nil, fmt.Errorf("no blackfire client credentials provided")
+	}
+
+	envs = append(envs, "BLACKFIRE_CLIENT_ID="+c.Blackfire.ClientID)
+	envs = append(envs, "BLACKFIRE_CLIENT_TOKEN="+c.Blackfire.ClientToken)
+
+	return envs, nil
+}
+
+// GetBlackfireServerCredentials is used to return the blackfire credentials from
+// the config
+func (c *Config) GetBlackfireServerCredentials() ([]string, error) {
 	var envs []string
 
 	if c.Blackfire.ServerID == "" || c.Blackfire.ServerToken == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -209,12 +209,11 @@ func (c *Config) AddContainer(container Container) error {
 // GetBlackfireClientCredentials is used to return the blackfire credentials from
 // the config
 func (c *Config) GetBlackfireClientCredentials() ([]string, error) {
-	var envs []string
-
 	if c.Blackfire.ClientID == "" || c.Blackfire.ClientToken == "" {
 		return nil, fmt.Errorf("no blackfire client credentials provided")
 	}
 
+	var envs []string
 	envs = append(envs, "BLACKFIRE_CLIENT_ID="+c.Blackfire.ClientID)
 	envs = append(envs, "BLACKFIRE_CLIENT_TOKEN="+c.Blackfire.ClientToken)
 
@@ -224,12 +223,11 @@ func (c *Config) GetBlackfireClientCredentials() ([]string, error) {
 // GetBlackfireServerCredentials is used to return the blackfire credentials from
 // the config
 func (c *Config) GetBlackfireServerCredentials() ([]string, error) {
-	var envs []string
-
 	if c.Blackfire.ServerID == "" || c.Blackfire.ServerToken == "" {
-		return nil, fmt.Errorf("no blackfire credentials provided")
+		return nil, fmt.Errorf("no blackfire server credentials provided")
 	}
 
+	var envs []string
 	envs = append(envs, "BLACKFIRE_SERVER_ID="+c.Blackfire.ServerID)
 	envs = append(envs, "BLACKFIRE_SERVER_TOKEN="+c.Blackfire.ServerToken)
 

--- a/pkg/svc/blackfire/blackfire.go
+++ b/pkg/svc/blackfire/blackfire.go
@@ -54,7 +54,7 @@ func VerifyCreated(ctx context.Context, cli client.CommonAPIClient, networkID st
 			return "", "", fmt.Errorf("unable to read output while pulling image, %w", err)
 		}
 
-		credentials, err := cfg.GetBlackfireCredentials()
+		credentials, err := cfg.GetBlackfireServerCredentials()
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/svc/blackfire/blackfire.go
+++ b/pkg/svc/blackfire/blackfire.go
@@ -1,0 +1,145 @@
+package blackfire
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/craftcms/nitro/pkg/config"
+	"github.com/craftcms/nitro/pkg/containerlabels"
+	"github.com/craftcms/nitro/pkg/terminal"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+)
+
+const (
+	// Image is the image to use for the blackfire container
+	Image = "docker.io/blackfire/blackfire:2"
+
+	// Host is the hostname for the blackfire container
+	Host = "blackfire.service.nitro"
+
+	// Label is the label value used to mark a container as a "blackfire" service
+	Label = "blackfire"
+)
+
+// VerifyCreated will verify that the blackfire service container exists and is started
+func VerifyCreated(ctx context.Context, cli client.CommonAPIClient, networkID string, cfg config.Config, output terminal.Outputer) (string, string, error) {
+	// add the filter
+	filter := filters.NewArgs()
+	filter.Add("label", containerlabels.Nitro+"=true")
+	filter.Add("label", containerlabels.Type+"="+Label)
+
+	// get a list of containers
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filter})
+	if err != nil {
+		return "", "", err
+	}
+
+	// if there is not a container, create one
+	if len(containers) == 0 {
+		// pull the image
+		r, err := cli.ImagePull(ctx, Image, types.ImagePullOptions{})
+		if err != nil {
+			return "", "", err
+		}
+
+		// read from the buffer to pull the image
+		buf := &bytes.Buffer{}
+		if _, err := buf.ReadFrom(r); err != nil {
+			return "", "", fmt.Errorf("unable to read output while pulling image, %w", err)
+		}
+
+		credentials, err := cfg.GetBlackfireCredentials()
+		if err != nil {
+			return "", "", err
+		}
+
+		containerConfig := &container.Config{
+			Image: Image,
+			Labels: map[string]string{
+				containerlabels.Nitro: "true",
+				containerlabels.Type:  Label,
+			},
+			Env: credentials,
+		}
+
+		networkConfig := &network.NetworkingConfig{
+			EndpointsConfig: map[string]*network.EndpointSettings{
+				"nitro-network": {
+					NetworkID: networkID,
+				},
+			},
+		}
+
+		// create the container
+		resp, err := cli.ContainerCreate(ctx, containerConfig, nil, networkConfig, nil, Host)
+		if err != nil {
+			return "", "", fmt.Errorf("unable to create the container, %w", err)
+		}
+
+		// start the container
+		if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+			return "", "", fmt.Errorf("unable to start the container, %w", err)
+		}
+
+		return resp.ID, Host, nil
+	}
+
+	// start each of the containers, there should only be one so the final return is an error
+	for _, c := range containers {
+		// start the container
+		if c.Status != "running" {
+			if err := cli.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
+				return "", "", fmt.Errorf("unable to start the container, %w", err)
+			}
+		}
+	}
+
+	return containers[0].ID, Host, nil
+}
+
+// VerifyRemoved will try verify the container is not created for the minio service. If we find any containers that are
+func VerifyRemoved(ctx context.Context, cli client.CommonAPIClient, output terminal.Outputer) error {
+	// add the filter
+	filter := filters.NewArgs()
+	filter.Add("label", containerlabels.Nitro+"=true")
+	filter.Add("label", containerlabels.Type+"="+Label)
+
+	// get a list of containers
+	containers, err := cli.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
+		Filters: filter,
+	})
+	if err != nil {
+		return err
+	}
+
+	// we are all good, nothing to do
+	if len(containers) == 0 {
+		return nil
+	}
+
+	timeout := time.Duration(time.Second * 30)
+
+	// remove all of the containers
+	for _, c := range containers {
+		// stop the container if its running
+		if c.State == "running" {
+			if err := cli.ContainerStop(ctx, c.ID, &timeout); err != nil {
+				return err
+			}
+		}
+
+		// remove the container
+		if err := cli.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{RemoveVolumes: true}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/svc/blackfire/blackfire.go
+++ b/pkg/svc/blackfire/blackfire.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/craftcms/nitro/pkg/config"
@@ -42,89 +43,140 @@ func VerifyCreated(ctx context.Context, cli client.CommonAPIClient, networkID st
 		return "", "", err
 	}
 
-	// if there is not a container, create one
-	if len(containers) == 0 {
-		// pull the image
-		r, err := cli.ImagePull(ctx, Image, types.ImagePullOptions{})
-		if err != nil {
-			return "", "", err
-		}
+	// if we have an existing container
+	if len(containers) > 0 {
+		// start each of the containers, there should only be one so the final return is an error
+		for _, c := range containers {
+			// start the container
+			if c.Status != "running" {
+				if err := cli.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
+					return "", "", fmt.Errorf("unable to start the container, %w", err)
+				}
+			}
 
-		// read from the buffer to pull the image
-		buf := &bytes.Buffer{}
-		if _, err := buf.ReadFrom(r); err != nil {
-			return "", "", fmt.Errorf("unable to read output while pulling image, %w", err)
-		}
+			// verify the container environment variables match
+			info, err := cli.ContainerInspect(ctx, c.ID)
+			if err != nil {
+				return "", "", err
+			}
 
-		credentials, err := cfg.GetBlackfireServerCredentials()
-		if err != nil {
-			return "", "", err
-		}
+			// get the blackfire server credentials from the config
+			credentials, err := cfg.GetBlackfireServerCredentials()
+			if err != nil {
+				return "", "", err
+			}
 
-		// set the nitro env overrides
-		httpPort := "8307"
-		if os.Getenv("NITRO_BLACKFIRE_PORT") != "" {
-			httpPort = os.Getenv("NITRO_BLACKFIRE_PORT")
-		}
+			// check the environment variables
+			matches := true
+			for _, env := range info.Config.Env {
+				// make sure the id matches
+				if strings.Contains(env, "BLACKFIRE_SERVER_ID") {
+					for _, credential := range credentials {
+						if strings.Contains(credential, "BLACKFIRE_SERVER_ID") {
+							if env != credential {
+								matches = false
+							}
+						}
+					}
+				}
 
-		httpPortNat, err := nat.NewPort("tcp", "8307")
-		if err != nil {
-			return "", "", fmt.Errorf("unable to create the port, %w", err)
-		}
+				// make sure the token matches
+				if strings.Contains(env, "BLACKFIRE_SERVER_TOKEN") {
+					for _, credential := range credentials {
+						if strings.Contains(credential, "BLACKFIRE_SERVER_TOKEN") {
+							if env != credential {
+								matches = false
+							}
+						}
+					}
+				}
+			}
 
-		containerConfig := &container.Config{
-			Image: Image,
-			Labels: map[string]string{
-				containerlabels.Nitro: "true",
-				containerlabels.Type:  Label,
-			},
-			Env: credentials,
-		}
+			// if everything is good, just return the information we need
+			if matches {
+				return containers[0].ID, Host, nil
+			}
 
-		hostConfig := &container.HostConfig{
-			PortBindings: map[nat.Port][]nat.PortBinding{
-				httpPortNat: {
-					{
-						HostIP:   "127.0.0.1",
-						HostPort: httpPort,
-					},
-				},
-			},
-		}
-
-		networkConfig := &network.NetworkingConfig{
-			EndpointsConfig: map[string]*network.EndpointSettings{
-				"nitro-network": {
-					NetworkID: networkID,
-				},
-			},
-		}
-
-		// create the container
-		resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, networkConfig, nil, Host)
-		if err != nil {
-			return "", "", fmt.Errorf("unable to create the container, %w", err)
-		}
-
-		// start the container
-		if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
-			return "", "", fmt.Errorf("unable to start the container, %w", err)
-		}
-
-		return resp.ID, Host, nil
-	}
-
-	// start each of the containers, there should only be one so the final return is an error
-	for _, c := range containers {
-		// start the container
-		if c.Status != "running" {
-			if err := cli.ContainerStart(ctx, c.ID, types.ContainerStartOptions{}); err != nil {
-				return "", "", fmt.Errorf("unable to start the container, %w", err)
+			// if we got here, we need to remove the container
+			if err := cli.ContainerRemove(ctx, c.ID, types.ContainerRemoveOptions{Force: true}); err != nil {
+				return "", "", err
 			}
 		}
 	}
 
-	return containers[0].ID, Host, nil
+	// always fall back to creating the containerr
+	return create(ctx, cli, networkID, cfg)
+}
+
+func create(ctx context.Context, cli client.CommonAPIClient, networkID string, cfg config.Config) (string, string, error) {
+	// pull the image
+	r, err := cli.ImagePull(ctx, Image, types.ImagePullOptions{})
+	if err != nil {
+		return "", "", err
+	}
+
+	// read from the buffer to pull the image
+	buf := &bytes.Buffer{}
+	if _, err := buf.ReadFrom(r); err != nil {
+		return "", "", fmt.Errorf("unable to read output while pulling image, %w", err)
+	}
+
+	credentials, err := cfg.GetBlackfireServerCredentials()
+	if err != nil {
+		return "", "", err
+	}
+
+	// set the nitro env overrides
+	httpPort := "8307"
+	if os.Getenv("NITRO_BLACKFIRE_PORT") != "" {
+		httpPort = os.Getenv("NITRO_BLACKFIRE_PORT")
+	}
+
+	httpPortNat, err := nat.NewPort("tcp", "8307")
+	if err != nil {
+		return "", "", fmt.Errorf("unable to create the port, %w", err)
+	}
+
+	containerConfig := &container.Config{
+		Image: Image,
+		Labels: map[string]string{
+			containerlabels.Nitro: "true",
+			containerlabels.Type:  Label,
+		},
+		Env: credentials,
+	}
+
+	hostConfig := &container.HostConfig{
+		PortBindings: map[nat.Port][]nat.PortBinding{
+			httpPortNat: {
+				{
+					HostIP:   "127.0.0.1",
+					HostPort: httpPort,
+				},
+			},
+		},
+	}
+
+	networkConfig := &network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			"nitro-network": {
+				NetworkID: networkID,
+			},
+		},
+	}
+
+	// create the container
+	resp, err := cli.ContainerCreate(ctx, containerConfig, hostConfig, networkConfig, nil, Host)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to create the container, %w", err)
+	}
+
+	// start the container
+	if err := cli.ContainerStart(ctx, resp.ID, types.ContainerStartOptions{}); err != nil {
+		return "", "", fmt.Errorf("unable to start the container, %w", err)
+	}
+
+	return resp.ID, Host, nil
 }
 
 // VerifyRemoved will try verify the container is not created for the minio service. If we find any containers that are

--- a/pkg/svc/blackfire/blackfire_test.go
+++ b/pkg/svc/blackfire/blackfire_test.go
@@ -123,6 +123,20 @@ func TestVerifyCreated(t *testing.T) {
 							State: "not-running",
 						},
 					},
+					containerInspectResponse: types.ContainerJSON{
+						Config: &container.Config{
+							Env: []string{
+								"BLACKFIRE_SERVER_ID=123",
+								"BLACKFIRE_SERVER_TOKEN=123",
+							},
+						},
+					},
+				},
+				cfg: config.Config{
+					Blackfire: config.Blackfire{
+						ServerID:    "123",
+						ServerToken: "123",
+					},
 				},
 				networkID: "some-network-id",
 			},
@@ -354,6 +368,9 @@ type mockClient struct {
 	containerCreateResponse container.ContainerCreateCreatedBody
 	containerCreateError    error
 
+	// container inspect
+	containerInspectResponse types.ContainerJSON
+
 	// mock start
 	containerStartID      string
 	containerStartOptions types.ContainerStartOptions
@@ -398,6 +415,10 @@ func (c *mockClient) ContainerCreate(ctx context.Context, config *container.Conf
 	}
 
 	return c.containerCreateResponse, c.containerCreateError
+}
+
+func (c *mockClient) ContainerInspect(ctx context.Context, id string) (types.ContainerJSON, error) {
+	return c.containerInspectResponse, nil
 }
 
 func (c *mockClient) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {

--- a/pkg/svc/blackfire/blackfire_test.go
+++ b/pkg/svc/blackfire/blackfire_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
@@ -88,7 +89,16 @@ func TestVerifyCreated(t *testing.T) {
 						"BLACKFIRE_SERVER_TOKEN=servertoken",
 					},
 				},
-				HostConfig: nil,
+				HostConfig: &container.HostConfig{
+					PortBindings: map[nat.Port][]nat.PortBinding{
+						"8307/tcp": {
+							{
+								HostIP:   "127.0.0.1",
+								HostPort: "8307",
+							},
+						},
+					},
+				},
 				NetworkingConfig: &network.NetworkingConfig{
 					EndpointsConfig: map[string]*network.EndpointSettings{
 						"nitro-network": {

--- a/pkg/svc/blackfire/blackfire_test.go
+++ b/pkg/svc/blackfire/blackfire_test.go
@@ -1,0 +1,426 @@
+package blackfire
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/craftcms/nitro/pkg/config"
+	"github.com/craftcms/nitro/pkg/containerlabels"
+	"github.com/craftcms/nitro/pkg/terminal"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestVerifyCreated(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		spy       *mockClient
+		networkID string
+		cfg       config.Config
+		output    terminal.Outputer
+	}
+	tests := []struct {
+		name string
+		args args
+
+		customEnvs map[string]string
+
+		// spys
+		wantSpyContainerListOptions  types.ContainerListOptions
+		wantSpyImagePullImage        string
+		wantSpyImagePullOptions      types.ImagePullOptions
+		wantSpyContainerCreateConfig types.ContainerCreateConfig
+		wantSpyContainerCreateHost   string
+		wantSpyContainerStartID      string
+		wantSpyContainerStartOptions types.ContainerStartOptions
+
+		// response
+		wantID       string
+		wantHostname string
+		wantErr      bool
+	}{
+		{
+			name: "container is created when it does not exist",
+			args: args{
+				ctx: context.Background(),
+				spy: &mockClient{
+					containerCreateResponse: container.ContainerCreateCreatedBody{
+						ID: "someid",
+					},
+				},
+				cfg: config.Config{
+					Blackfire: config.Blackfire{
+						ServerID:    "serverid",
+						ServerToken: "servertoken",
+					},
+				},
+				networkID: "some-network-id",
+			},
+			wantSpyContainerListOptions: types.ContainerListOptions{
+				All: true,
+				Filters: filters.NewArgs(
+					filters.KeyValuePair{Key: "label", Value: containerlabels.Nitro + "=true"},
+					filters.KeyValuePair{Key: "label", Value: containerlabels.Type + "=blackfire"},
+				),
+			},
+			wantSpyImagePullImage: "docker.io/blackfire/blackfire:2",
+			wantSpyContainerCreateConfig: types.ContainerCreateConfig{
+				Name: "blackfire.service.nitro",
+				Config: &container.Config{
+					Image: "docker.io/blackfire/blackfire:2",
+					Labels: map[string]string{
+						containerlabels.Nitro: "true",
+						containerlabels.Type:  "blackfire",
+					},
+					Env: []string{
+						"BLACKFIRE_SERVER_ID=serverid",
+						"BLACKFIRE_SERVER_TOKEN=servertoken",
+					},
+				},
+				HostConfig: nil,
+				NetworkingConfig: &network.NetworkingConfig{
+					EndpointsConfig: map[string]*network.EndpointSettings{
+						"nitro-network": {
+							NetworkID: "some-network-id",
+						},
+					},
+				},
+			},
+			wantSpyContainerStartID: "someid",
+			wantID:                  "someid",
+			wantHostname:            "blackfire.service.nitro",
+			wantErr:                 false,
+		},
+		{
+			name: "containers that are already created are started",
+			args: args{
+				ctx: context.Background(),
+				spy: &mockClient{
+					containers: []types.Container{
+						{
+							ID:    "existing-container-id",
+							State: "not-running",
+						},
+					},
+				},
+				networkID: "some-network-id",
+			},
+			wantSpyContainerListOptions: types.ContainerListOptions{
+				All: true,
+				Filters: filters.NewArgs(
+					filters.KeyValuePair{Key: "label", Value: containerlabels.Nitro + "=true"},
+					filters.KeyValuePair{Key: "label", Value: containerlabels.Type + "=blackfire"},
+				),
+			},
+			wantSpyContainerStartID: "existing-container-id",
+			wantID:                  "existing-container-id",
+			wantHostname:            "blackfire.service.nitro",
+			wantErr:                 false,
+		},
+		{
+			name: "error on container list returns error",
+			args: args{
+				ctx: context.Background(),
+				spy: &mockClient{
+					containerListError: fmt.Errorf("unknown error"),
+				},
+			},
+			wantSpyContainerListOptions: types.ContainerListOptions{
+				All: true,
+				Filters: filters.NewArgs(
+					filters.KeyValuePair{Key: "label", Value: containerlabels.Nitro + "=true"},
+					filters.KeyValuePair{Key: "label", Value: containerlabels.Type + "=blackfire"},
+				),
+			},
+			wantID:       "",
+			wantHostname: "",
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		// set any custom envs
+		for k, v := range tt.customEnvs {
+			os.Setenv(k, v)
+			defer os.Unsetenv(k)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			id, hostname, err := VerifyCreated(tt.args.ctx, tt.args.spy, tt.args.networkID, tt.args.cfg, tt.args.output)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VerifyCreated() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if id != tt.wantID {
+				t.Errorf("VerifyCreated() got = %v, want %v", id, tt.wantID)
+			}
+			if hostname != tt.wantHostname {
+				t.Errorf("VerifyCreated() got1 = %v, want %v", hostname, tt.wantHostname)
+			}
+
+			// spy checks
+
+			// check the container remove options
+			if !reflect.DeepEqual(tt.wantSpyContainerListOptions, tt.args.spy.containerListOptions) {
+				t.Errorf("expected the container list options to to match, got %v want %v", tt.args.spy.containerListOptions, tt.wantSpyContainerListOptions)
+			}
+
+			if tt.wantSpyImagePullImage != tt.args.spy.imagePullImage {
+				t.Errorf("expected the image pull images to match, got %s want %s", tt.args.spy.imagePullImage, tt.wantSpyImagePullImage)
+			}
+
+			if !reflect.DeepEqual(tt.wantSpyContainerCreateConfig, tt.args.spy.containerCreateConfig) {
+				t.Errorf("expected the container create config to to match, got %v want %v", tt.args.spy.containerCreateConfig, tt.wantSpyContainerCreateConfig)
+			}
+
+			if tt.wantSpyContainerStartID != tt.args.spy.containerStartID {
+				t.Errorf("expected the container start ids to match, got %s want %s", tt.args.spy.containerStartID, tt.wantSpyContainerStartID)
+			}
+
+			if !reflect.DeepEqual(tt.wantSpyContainerStartOptions, tt.args.spy.containerStartOptions) {
+				t.Errorf("expected the container start options to to match, got %v want %v", tt.args.spy.containerCreateConfig, tt.wantSpyContainerCreateConfig)
+			}
+		})
+	}
+}
+
+func TestVerifyRemoved(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		spy    *mockClient
+		output terminal.Outputer
+	}
+	tests := []struct {
+		name                       string
+		args                       args
+		wantContainerStopID        string
+		wantContainerRemoveID      string
+		wantContainerRemoveOptions types.ContainerRemoveOptions
+		wantErr                    bool
+	}{
+		{
+			name: "stops and removes containers when they are present and running",
+			args: args{
+				ctx: context.TODO(),
+				spy: &mockClient{
+					containers: []types.Container{
+						{
+							ID:    "some-random-id",
+							State: "running",
+						},
+					},
+				},
+			},
+			wantContainerStopID:        "some-random-id",
+			wantContainerRemoveID:      "some-random-id",
+			wantContainerRemoveOptions: types.ContainerRemoveOptions{RemoveVolumes: true},
+			wantErr:                    false,
+		},
+		{
+			name: "container stop returns error",
+			args: args{
+				ctx: context.TODO(),
+				spy: &mockClient{
+					containers: []types.Container{
+						{
+							ID:    "some-random-id",
+							State: "running",
+						},
+					},
+					containerStopError: fmt.Errorf("docker container stop error"),
+				},
+			},
+			wantContainerStopID: "some-random-id",
+			wantErr:             true,
+		},
+		{
+			name: "container remove returns error",
+			args: args{
+				ctx: context.TODO(),
+				spy: &mockClient{
+					containers: []types.Container{
+						{
+							ID:    "some-random-id",
+							State: "running",
+						},
+					},
+					containerRemoveError: fmt.Errorf("docker container remove error"),
+				},
+			},
+			wantContainerStopID:        "some-random-id",
+			wantContainerRemoveID:      "some-random-id",
+			wantContainerRemoveOptions: types.ContainerRemoveOptions{RemoveVolumes: true},
+			wantErr:                    true,
+		},
+		{
+			name: "non running containers do not get a stop request",
+			args: args{
+				ctx: context.TODO(),
+				spy: &mockClient{
+					containers: []types.Container{
+						{
+							ID:    "some-random-id",
+							State: "anything",
+						},
+					},
+				},
+			},
+			wantContainerStopID:        "",
+			wantContainerRemoveID:      "some-random-id",
+			wantContainerRemoveOptions: types.ContainerRemoveOptions{RemoveVolumes: true},
+			wantErr:                    false,
+		},
+		{
+			name: "returns no error when no containers are present",
+			args: args{
+				ctx: context.TODO(),
+				spy: &mockClient{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns error when unable to get a list of containers",
+			args: args{
+				ctx: context.TODO(),
+				spy: &mockClient{
+					containerListError: fmt.Errorf("mock error"),
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// check for the error
+			if err := VerifyRemoved(tt.args.ctx, tt.args.spy, tt.args.output); (err != nil) != tt.wantErr {
+				t.Errorf("VerifyRemoved() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// check the container stop id
+			if tt.wantContainerStopID != "" {
+				if tt.wantContainerStopID != tt.args.spy.containerStopID {
+					t.Errorf("expected the container stop ids to match, got %s want %s", tt.args.spy.containerStopID, tt.wantContainerStopID)
+				}
+			}
+
+			// check the container remove id
+			if tt.wantContainerRemoveID != "" {
+				if tt.wantContainerRemoveID != tt.args.spy.containerRemoveID {
+					t.Errorf("expected the container remove ids to match, got %s want %s", tt.args.spy.containerRemoveID, tt.wantContainerRemoveID)
+				}
+			}
+
+			// check the container remove options
+			if !reflect.DeepEqual(tt.wantContainerRemoveOptions, tt.args.spy.containerRemoveOptions) {
+				t.Errorf("expected the container remove options to to match, got %v want %v", tt.args.spy.containerRemoveOptions, tt.wantContainerRemoveOptions)
+			}
+		})
+	}
+}
+
+type mockClient struct {
+	client.CommonAPIClient
+
+	// filters are the filters passed to list funcs
+	filterArgs []filters.Args
+
+	// mock storage
+	containers           []types.Container
+	containerListOptions types.ContainerListOptions
+	containerListError   error
+
+	// container create
+	containerCreateConfig   types.ContainerCreateConfig
+	containerCreateResponse container.ContainerCreateCreatedBody
+	containerCreateError    error
+
+	// mock start
+	containerStartID      string
+	containerStartOptions types.ContainerStartOptions
+	containerStartError   error
+
+	// mock stop
+	containerStopID    string
+	containerStopError error
+
+	// mock remove
+	containerRemoveID      string
+	containerRemoveOptions types.ContainerRemoveOptions
+	containerRemoveError   error
+
+	// image pull
+	imagePullReaderCloser io.ReadCloser
+	imagePullImage        string
+	imagePullOptions      types.ImagePullOptions
+	imagePullError        error
+}
+
+func (c *mockClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	c.filterArgs = append(c.filterArgs, options.Filters)
+	c.containerListOptions = options
+
+	return c.containers, c.containerListError
+}
+
+func (c *mockClient) ContainerRemove(ctx context.Context, containerID string, opts types.ContainerRemoveOptions) error {
+	c.containerRemoveID = containerID
+	c.containerRemoveOptions = opts
+
+	return c.containerRemoveError
+}
+
+func (c *mockClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *v1.Platform, containerName string) (container.ContainerCreateCreatedBody, error) {
+	c.containerCreateConfig = types.ContainerCreateConfig{
+		Name:             containerName,
+		Config:           config,
+		HostConfig:       hostConfig,
+		NetworkingConfig: networkingConfig,
+	}
+
+	return c.containerCreateResponse, c.containerCreateError
+}
+
+func (c *mockClient) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
+	c.containerStartID = container
+	c.containerStartOptions = options
+
+	return c.containerStartError
+}
+
+func (c *mockClient) ContainerStop(ctx context.Context, containerID string, timeout *time.Duration) error {
+	c.containerStopID = containerID
+
+	return c.containerStopError
+}
+
+// func (c *mockClient) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error) {
+// 	// TODO(jasonmccallister) remove this hacked method
+// 	summary := []types.ImageSummary{
+// 		{
+// 			Containers: 1,
+// 		},
+// 	}
+
+// 	return summary, nil
+// }
+
+func (c *mockClient) ImagePull(ctx context.Context, image string, opts types.ImagePullOptions) (io.ReadCloser, error) {
+	c.imagePullOptions = opts
+	c.imagePullImage = image
+
+	if c.imagePullReaderCloser == nil {
+		c.imagePullReaderCloser = ioutil.NopCloser(ioutil.NopCloser(strings.NewReader("")))
+	}
+
+	return c.imagePullReaderCloser, c.imagePullError
+}


### PR DESCRIPTION
### Description

Adds the `nitro enable blackfire` command which makes its own service container for the blackfire agent. Updates the sites container to use the `BLACKFIRE_AGENT_SOCKET` configuration.

### To do

- [x] Add client id and token to the Nitro config and populate the site container environment variables
- [x] Check if the blackfire container environment variables have changed
- [x] Allow overriding the port with `NITRO_BLACKFIRE_PORT`
