### PR TITLE
Adds `db shell` command

### DIFF
--- a/command/database/database.go
+++ b/command/database/database.go
@@ -34,6 +34,7 @@ func NewCommand(home string, docker client.CommonAPIClient, nitrod protob.NitroC
 		backupCommand(home, docker, output),
 		addCommand(docker, nitrod, output),
 		sshCommand(home, docker, output),
+		shellCommand(home, docker, output),
 		removeCommand(docker, nitrod, output),
 		newCommand(home, docker, output),
 		destroyCommand(home, docker, output),

--- a/command/database/shell.go
+++ b/command/database/shell.go
@@ -1,0 +1,88 @@
+package database
+
+import (
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/craftcms/nitro/pkg/containerlabels"
+	"github.com/craftcms/nitro/pkg/terminal"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+)
+
+var shellExampleText = `  # open an interactive database shell
+  nitro db shell`
+
+func shellCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "shell",
+		Short:   "Opens an interactive database shell.",
+		Example: shellExampleText,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// add filters to show only the environment and database containers
+			filter := filters.NewArgs()
+			filter.Add("label", containerlabels.Nitro)
+			filter.Add("label", containerlabels.Type+"=database")
+
+			// get a list of all the databases
+			containers, err := docker.ContainerList(cmd.Context(), types.ContainerListOptions{Filters: filter})
+			if err != nil {
+				return err
+			}
+
+			// sort containers by the name
+			sort.SliceStable(containers, func(i, j int) bool {
+				return containers[i].Names[0] < containers[j].Names[0]
+			})
+
+			// generate a list of engines for the prompt
+			var containerList []string
+			for _, c := range containers {
+				// start the container if not running
+				if c.State != "running" {
+					for _, command := range cmd.Root().Commands() {
+						if command.Use == "start" {
+							if err := command.RunE(cmd, []string{}); err != nil {
+								return err
+							}
+						}
+					}
+				}
+
+				containerList = append(containerList, strings.TrimLeft(c.Names[0], "/"))
+			}
+
+			// prompt for the container to ssh into
+			selected, err := output.Select(cmd.InOrStdin(), "Select a database to connect to: ", containerList)
+			if err != nil {
+				return err
+			}
+
+			container := containerList[selected]
+
+			return databaseInteractiveShellConnect(output, container)
+		},
+	}
+
+	return cmd
+}
+
+func databaseInteractiveShellConnect(output terminal.Outputer, containerName string) error {
+	// find the docker executable
+	cli, err := exec.LookPath("docker")
+	if err != nil {
+		return err
+	}
+
+  c := exec.Command(cli, "exec", "-u", "root", "-it", containerName, "mysql", "-h", "localhost", "-u", "nitro", "-pnitro")
+
+	c.Stdin = os.Stdin
+	c.Stderr = os.Stderr
+	c.Stdout = os.Stdout
+
+	return c.Run()
+}


### PR DESCRIPTION
### Description

Adds a basic `nitro db shell` command taking heavy inspiration from `nitro db ssh`. I noticed that the username and password `nitro` are hardcoded in other areas of the Nitro project, so I felt I could safely assume that `nitro` will always be the correct DB username and password. Please let me know if this isn't the case.

I'm super welcome to any other feedback. Go isn't a very familiar language to me.

### Related issues

https://github.com/craftcms/nitro/issues/410