### PR TITLE
Add ability to exclude files/directories 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN GOOS=linux go build -ldflags="-s -w -X 'github.com/craftcms/nitro/pkg/api/api.Version=${NITRO_VERSION}'" -o nitrod ./cmd/nitrod
 
 # build the final image
-FROM alpine:3.14
+FROM alpine:3
 
 # See https://caddyserver.com/docs/conventions#file-locations for details
 ENV XDG_CONFIG_HOME /config

--- a/command/apply/internal/sitecontainer/sitecontainer.go
+++ b/command/apply/internal/sitecontainer/sitecontainer.go
@@ -175,6 +175,12 @@ func create(ctx context.Context, docker client.CommonAPIClient, home, networkID 
 		}
 	}
 
+	// determine if the site has any excludes
+	binds, err := site.GetBindMounts(home)
+	if err != nil {
+		return "", err
+	}
+
 	// set the labels
 	labels := containerlabels.ForSite(site)
 	// create the container
@@ -187,7 +193,7 @@ func create(ctx context.Context, docker client.CommonAPIClient, home, networkID 
 			Hostname: site.Hostname,
 		},
 		&container.HostConfig{
-			Binds:      []string{fmt.Sprintf("%s:/app:rw", path)},
+			Binds:      binds,
 			ExtraHosts: extraHosts,
 			Mounts: []mount.Mount{
 				{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/craftcms/nitro/pkg/bindmounts"
 	"github.com/craftcms/nitro/pkg/helpers"
 
 	"gopkg.in/yaml.v3"
@@ -281,6 +282,7 @@ type Site struct {
 	Webroot    string   `json:"webroot" yaml:"webroot"`
 	Xdebug     bool     `json:"xdebug" yaml:"xdebug"`
 	Blackfire  bool     `json:"blackfire" yaml:"blackfire"`
+	Excludes   []string `json:"excludes,omitempty" yaml:"excludes,omitempty"`
 }
 
 // GetAbsPath gets the directory for a site.Path,
@@ -288,6 +290,31 @@ type Site struct {
 // container.
 func (s *Site) GetAbsPath(home string) (string, error) {
 	return cleanPath(home, s.Path)
+}
+
+// GetBindMounts takes the users home directory and will return a
+// list of bind mounts that checks the excludes on the site.
+func (s *Site) GetBindMounts(home string) ([]string, error) {
+	// get the abs path for the site
+	path, err := s.GetAbsPath(home)
+	if err != nil {
+		return nil, err
+	}
+
+	// are there files or directories we should exclude?
+	if len(s.Excludes) > 0 {
+		var binds []string
+		for _, v := range bindmounts.FromDir(path, s.Excludes) {
+			_, f := filepath.Split(v)
+
+			binds = append(binds, fmt.Sprintf("%s:/app/%s:rw", v, f))
+		}
+
+		return binds, nil
+	}
+
+	// return the entire directory as the bind mount
+	return []string{fmt.Sprintf("%s:/app:rw", path)}, nil
 }
 
 // GetAbsContainerPath gets the directory for a site’s


### PR DESCRIPTION
### Description
One of the major performance hits on Docker Desktop for macOS and Windows is the file sync performance. This add's the ability to exclude directories (and files) from being bind mounted from the host OS to the container in an effort to improve Docker for Desktop performance. Linux users might not see a performance hit, but it should help with file permissions on things that need to be writable in the container (e.g. `storage`, `vendor`). 

We will need to test to verify performance improvements on macOS and Windows but this should help alleviate some negative performance impacts.

This does mean that if the `storage` and `vendor` directories are excluded, the user must manually create those in the container using `nitro ssh <sitename>`.  

For now, the best way to add excludes is to add it manually using `nitro edit` and update to reflect the directories or files tp exclude:

```yaml
  - hostname: europa.nitro
    path: ~/dev/demo-europa-museum
    version: "8.0"
    webroot: web
    xdebug: false
    blackfire: false
    excludes:
      - vendor
      - storage
```

_**Note**: There is no UI to add/edit the excludes but perhaps we could prompt the user during `nitro add`?_

### Related issues
#391 
#409 

### TODOs

- [ ] Update the match logic to check for new files or directories during `nitro apply`
- [ ] Update the `nitro add` logic to include this new capability
- [ ] Consider adding inline docs (links?) to note the "problems" when excluding specific directories (e.g. white page when excluding `vendor` and _Storage is not writable by PHP_ when `storage` is excluded (@mattstein)) 
