### PR TITLE
Feature/restructure service commands

### DIFF
--- a/command/ls/ls.go
+++ b/command/ls/ls.go
@@ -75,7 +75,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				}
 
 				if cmd.Flag("services").Value.String() == "true" {
-					if c.Labels[containerlabels.Type] != "dynamodb" && c.Labels[containerlabels.Type] != "mailhog" && c.Labels[containerlabels.Type] != "redis" && c.Labels[containerlabels.Type] != "blackfire" {
+					if containerlabels.IsServiceContainer(c.Labels) {
 						continue
 					}
 				}

--- a/command/ls/ls.go
+++ b/command/ls/ls.go
@@ -34,13 +34,14 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 		Short:   "Lists details for Nitro’s containers.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
 
 			// add filters to show only the environment and database containers
 			filter := filters.NewArgs()
 			filter.Add("label", containerlabels.Nitro)
 
 			// get a list of all the databases
-			containers, err := docker.ContainerList(cmd.Context(), types.ContainerListOptions{All: true, Filters: filter})
+			containers, err := docker.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filter})
 			if err != nil {
 				return err
 			}
@@ -74,7 +75,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				}
 
 				if cmd.Flag("services").Value.String() == "true" {
-					if c.Labels[containerlabels.Type] != "dynamodb" && c.Labels[containerlabels.Type] != "mailhog" && c.Labels[containerlabels.Type] != "redis"  && c.Labels[containerlabels.Type] != "blackfire" {
+					if c.Labels[containerlabels.Type] != "dynamodb" && c.Labels[containerlabels.Type] != "mailhog" && c.Labels[containerlabels.Type] != "redis" && c.Labels[containerlabels.Type] != "blackfire" {
 						continue
 					}
 				}
@@ -102,7 +103,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					intPorts = append(intPorts, "80", "443", "3000-3005")
 					// TODO(jasonmccallister) set the external ports from the environment variables
 					extPorts = append(extPorts, "80", "443", "3000-3005")
-				}  else {
+				} else {
 					for _, p := range c.Ports {
 						// get the external ports and assign if not 0
 						e := p.PublicPort
@@ -121,7 +122,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				internalPorts := strings.Join(intPorts, ",")
 				externalPorts := strings.Join(extPorts, ",")
 
-				tbl.AddRow(strings.TrimLeft(c.Names[0], "/"), containerlabels.Identify(c),externalPorts, internalPorts, status)
+				tbl.AddRow(strings.TrimLeft(c.Names[0], "/"), containerlabels.Identify(c), externalPorts, internalPorts, status)
 			}
 
 			tbl.Print()

--- a/command/nitro/nitro.go
+++ b/command/nitro/nitro.go
@@ -17,9 +17,7 @@ import (
 	"github.com/craftcms/nitro/command/create"
 	"github.com/craftcms/nitro/command/database"
 	"github.com/craftcms/nitro/command/destroy"
-	"github.com/craftcms/nitro/command/disable"
 	"github.com/craftcms/nitro/command/edit"
-	"github.com/craftcms/nitro/command/enable"
 	"github.com/craftcms/nitro/command/extensions"
 	"github.com/craftcms/nitro/command/hosts"
 	"github.com/craftcms/nitro/command/iniset"
@@ -34,6 +32,7 @@ import (
 	"github.com/craftcms/nitro/command/remove"
 	"github.com/craftcms/nitro/command/restart"
 	"github.com/craftcms/nitro/command/selfupdate"
+	"github.com/craftcms/nitro/command/service"
 	"github.com/craftcms/nitro/command/share"
 	"github.com/craftcms/nitro/command/ssh"
 	"github.com/craftcms/nitro/command/start"
@@ -111,8 +110,8 @@ func NewCommand() *cobra.Command {
 		create.NewCommand(home, docker, downloader, term),
 		database.NewCommand(home, docker, nitrod, term),
 		destroy.NewCommand(home, docker, term),
-		disable.NewCommand(home, docker, term),
-		enable.NewCommand(home, docker, term),
+		//disable.NewCommand(home, docker, term),
+		service.NewCommand(home, docker, term),
 		edit.NewCommand(home, docker, term),
 		extensions.NewCommand(home, docker, term),
 		hosts.NewCommand(home, term),

--- a/command/service/disable.go
+++ b/command/service/disable.go
@@ -11,8 +11,6 @@ import (
 	"github.com/craftcms/nitro/pkg/terminal"
 )
 
-// NewCommand returns the command to enable common nitro services. These services are provided as containers
-// and do not require a user to configure the ports/volumes or images.
 func disableCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "disable",

--- a/command/service/disable.go
+++ b/command/service/disable.go
@@ -15,8 +15,9 @@ import (
 // and do not require a user to configure the ports/volumes or images.
 func disableCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "disable",
-		Short: "Disables a service.",
+		Use:     "disable",
+		Aliases: []string{"dis"},
+		Short:   "Disables a service.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Println(cmd.UsageString())

--- a/command/service/disable.go
+++ b/command/service/disable.go
@@ -73,7 +73,7 @@ func disableCommand(home string, docker client.CommonAPIClient, output terminal.
 				return fmt.Errorf("unable to save config, %w", err)
 			}
 
-			output.Info("Successfully disabled", args[0]+"!", "✨")
+			output.Info("Disabled", args[0])
 
 			return nil
 		},

--- a/command/service/enable.go
+++ b/command/service/enable.go
@@ -18,8 +18,9 @@ var (
 
 func enableCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "enable",
-		Short: "Enables a service.",
+		Use:     "enable",
+		Aliases: []string{"en"},
+		Short:   "Enables a service.",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				fmt.Println(cmd.UsageString())
@@ -30,7 +31,7 @@ func enableCommand(home string, docker client.CommonAPIClient, output terminal.O
 			return nil
 		},
 		ValidArgs: []string{"blackfire", "dynamodb", "mailhog", "minio", "redis"},
-		Example:   `  # enable services
+		Example: `  # enable services
   nitro service enable <service-name>
 
   # enable mailhog for local email testing
@@ -76,7 +77,7 @@ func enableCommand(home string, docker client.CommonAPIClient, output terminal.O
 				return fmt.Errorf("unable to save config, %w", err)
 			}
 
-			output.Info("Successfully enabled", args[0] + "!", "💥")
+			output.Info("Successfully enabled", args[0]+"!", "💥")
 
 			return nil
 		},

--- a/command/service/enable.go
+++ b/command/service/enable.go
@@ -77,7 +77,7 @@ func enableCommand(home string, docker client.CommonAPIClient, output terminal.O
 				return fmt.Errorf("unable to save config, %w", err)
 			}
 
-			output.Info("Successfully enabled", args[0]+"!", "💥")
+			output.Info("Enabled", args[0])
 
 			return nil
 		},

--- a/command/service/enable.go
+++ b/command/service/enable.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/craftcms/nitro/pkg/prompt"
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+
+	"github.com/craftcms/nitro/pkg/config"
+	"github.com/craftcms/nitro/pkg/terminal"
+)
+
+var (
+	// ErrUnknownService is used when an unknown service is requested
+	ErrUnknownService = fmt.Errorf("unknown service requested")
+)
+
+func enableCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enables a service.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				fmt.Println(cmd.UsageString())
+
+				return fmt.Errorf("service name param missing")
+			}
+
+			return nil
+		},
+		ValidArgs: []string{"blackfire", "dynamodb", "mailhog", "minio", "redis"},
+		Example:   `  # enable services
+  nitro service enable <service-name>
+
+  # enable mailhog for local email testing
+  nitro service enable mailhog
+
+  # enable blackfire for local profiling
+  nitro service enable blackfire
+
+  # enable minio for local s3 testing
+  nitro service enable minio
+
+  # enable dynamodb for local noSQL
+  nitro service enable dynamodb`,
+		PostRunE: func(cmd *cobra.Command, args []string) error {
+			return prompt.RunApply(cmd, args, false, output)
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// load the configuration
+			cfg, err := config.Load(home)
+			if err != nil {
+				return err
+			}
+
+			// enable the service
+			switch args[0] {
+			case "blackfire":
+				// TODO(jasonmccallister) verify the credentials are set
+				cfg.Services.Blackfire = true
+			case "dynamodb":
+				cfg.Services.DynamoDB = true
+			case "mailhog":
+				cfg.Services.Mailhog = true
+			case "minio":
+				cfg.Services.Minio = true
+			case "redis":
+				cfg.Services.Redis = true
+			default:
+				return ErrUnknownService
+			}
+
+			// save the config file
+			if err := cfg.Save(); err != nil {
+				return fmt.Errorf("unable to save config, %w", err)
+			}
+
+			output.Info("Successfully enabled", args[0] + "!", "💥")
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/command/service/ls.go
+++ b/command/service/ls.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/craftcms/nitro/pkg/containerlabels"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/rodaine/table"
+	"github.com/spf13/cobra"
+
+	"github.com/craftcms/nitro/pkg/terminal"
+)
+
+func lsCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "Lists details for Nitro’s services.",
+		Example: `  # view information about your nitro environment
+  nitro service ls`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			// add filters to show only the environment and database containers
+			filter := filters.NewArgs()
+			filter.Add("label", containerlabels.Nitro)
+
+			// get a list of all the databases
+			containers, err := docker.ContainerList(ctx, types.ContainerListOptions{All: true, Filters: filter})
+			if err != nil {
+				return err
+			}
+
+			// sort containers by the name
+			sort.SliceStable(containers, func(i, j int) bool {
+				return containers[i].Names[0] < containers[j].Names[0]
+			})
+
+			// define the table headers
+			tbl := table.New("Hostname", "Type", "External Ports", "Internal Ports", "Status").WithWriter(cmd.OutOrStdout()).WithPadding(2)
+
+			for _, c := range containers {
+				status := "running"
+				if c.State == "exited" {
+					status = "stopped"
+				}
+
+				// show only the service containers
+				if c.Labels[containerlabels.Type] != "dynamodb" && c.Labels[containerlabels.Type] != "mailhog" && c.Labels[containerlabels.Type] != "redis" && c.Labels[containerlabels.Type] != "blackfire" {
+					continue
+				}
+
+				// get the ports
+				var intPorts, extPorts []string
+
+				// get ports
+				for _, p := range c.Ports {
+					// get the external ports and assign if not 0
+					e := p.PublicPort
+					if e != 0 {
+						extPorts = append(extPorts, fmt.Sprintf("%d", e))
+					}
+
+					// get the internal ports and assign if not 0
+					pr := p.PrivatePort
+					if e != 0 {
+						intPorts = append(intPorts, fmt.Sprintf("%d", pr))
+					}
+				}
+
+				internalPorts := strings.Join(intPorts, ",")
+				externalPorts := strings.Join(extPorts, ",")
+
+				tbl.AddRow(strings.TrimLeft(c.Names[0], "/"), containerlabels.Identify(c), externalPorts, internalPorts, status)
+			}
+
+			tbl.Print()
+
+			fmt.Println("\nNote: You can enable or disable services using `nitro service enable <service>`.")
+			fmt.Println("")
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/command/service/ls.go
+++ b/command/service/ls.go
@@ -17,8 +17,9 @@ import (
 
 func lsCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "ls",
-		Short: "Lists details for Nitro’s services.",
+		Use:     "ls",
+		Aliases: []string{"l"},
+		Short:   "Lists details for Nitro’s services.",
 		Example: `  # view information about your nitro environment
   nitro service ls`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/service/ls.go
+++ b/command/service/ls.go
@@ -50,7 +50,7 @@ func lsCommand(home string, docker client.CommonAPIClient, output terminal.Outpu
 				}
 
 				// show only the service containers
-				if c.Labels[containerlabels.Type] != "dynamodb" && c.Labels[containerlabels.Type] != "mailhog" && c.Labels[containerlabels.Type] != "redis" && c.Labels[containerlabels.Type] != "blackfire" {
+				if containerlabels.IsServiceContainer(c.Labels) {
 					continue
 				}
 

--- a/command/service/service.go
+++ b/command/service/service.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+
+	"github.com/craftcms/nitro/pkg/terminal"
+)
+
+const exampleText = `  # enable blackfire
+  nitro service enable blackfire`
+
+func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "service",
+		Short:   "Manage services.",
+		Example: exampleText,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(
+		enableCommand(home, docker, output),
+		disableCommand(home, docker, output),
+		lsCommand(home, docker, output),
+	)
+
+	return cmd
+}

--- a/command/service/service.go
+++ b/command/service/service.go
@@ -13,6 +13,7 @@ const exampleText = `  # enable blackfire
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "service",
+		Aliases: []string{"svc"},
 		Short:   "Manage services.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/command/xoff/xoff.go
+++ b/command/xoff/xoff.go
@@ -16,12 +16,12 @@ import (
 const exampleText = `  # example command
   nitro xoff`
 
-// NewCommand returns the command that is used to disable xdebug for a specific site. It will first check
-// if the current working directory or prompt the user for a site.
+// NewCommand returns the command that is used to disable xdebug for a specific app. It will first check
+// if the current working directory or prompt the user for an app.
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "xoff",
-		Short:   "Disables Xdebug for a site.",
+		Short:   "Disables Xdebug for an app.",
 		Example: exampleText,
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.RunApply(cmd, args, false, output)
@@ -55,7 +55,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			output.Info("Disabling xdebug for", app.Hostname)
 
-			// disable xdebug for the sites hostname
+			// disable xdebug for the app hostname
 			if err := cfg.DisableXdebug(app.Hostname); err != nil {
 				return err
 			}

--- a/command/xon/xon.go
+++ b/command/xon/xon.go
@@ -17,12 +17,12 @@ import (
 const exampleText = `  # example command
   nitro xon`
 
-// NewCommand returns the command that is used to enable xdebug for a specific site. It will first check
-// if the current working directory or prompt the user for a site.
+// NewCommand returns the command that is used to enable xdebug for a specific app. It will first check
+// if the current working directory or prompt the user for an app.
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "xon",
-		Short:   "Enables Xdebug for a site.",
+		Short:   "Enables Xdebug for an app.",
 		Example: exampleText,
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			return prompt.RunApply(cmd, args, false, output)
@@ -63,7 +63,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			// if blackfire is set, we need to disable it to profile the app
 			if app.Blackfire {
-				// disable blackfire for the sites hostname
+				// disable blackfire for the app hostname
 				if err := cfg.DisableBlackfire(app.Hostname); err != nil {
 					return err
 				}

--- a/pkg/containerlabels/containerlabels.go
+++ b/pkg/containerlabels/containerlabels.go
@@ -148,7 +148,7 @@ func Identify(c types.Container) string {
 
 // IsServiceContainer takes a containers labels and returns true if it is for a service container.
 func IsServiceContainer(labels map[string]string) bool {
-	if labels[Type] != "dynamodb" && labels[Type] != "mailhog" && labels[Type] != "redis" && labels[Type] != "blackfire" {
+	if labels[Type] == "dynamodb" || labels[Type] == "mailhog" || labels[Type] == "redis" || labels[Type] == "blackfire" {
 		return true
 	}
 

--- a/pkg/containerlabels/containerlabels.go
+++ b/pkg/containerlabels/containerlabels.go
@@ -3,7 +3,7 @@ package containerlabels
 import (
 	"strings"
 
-	 "github.com/craftcms/nitro/pkg/config"
+	"github.com/craftcms/nitro/pkg/config"
 	"github.com/docker/docker/api/types"
 )
 
@@ -144,4 +144,13 @@ func Identify(c types.Container) string {
 	}
 
 	return "app"
+}
+
+// IsServiceContainer takes a containers labels and returns true if it is for a service container.
+func IsServiceContainer(labels map[string]string) bool {
+	if labels[Type] != "dynamodb" && labels[Type] != "mailhog" && labels[Type] != "redis" && labels[Type] != "blackfire" {
+		return true
+	}
+
+	return false
 }

--- a/pkg/containerlabels/containerlabels_test.go
+++ b/pkg/containerlabels/containerlabels_test.go
@@ -1,0 +1,36 @@
+package containerlabels
+
+import "testing"
+
+func TestIsServiceContainer(t *testing.T) {
+	type args struct {
+		labels map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "returns true if the labels are for a service",
+			args: args{labels: map[string]string{
+				Type: "dynamodb",
+			}},
+			want: true,
+		},
+		{
+			name: "returns true if the labels are for a service",
+			args: args{labels: map[string]string{
+				Host: "anything",
+			}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsServiceContainer(tt.args.labels); got != tt.want {
+				t.Errorf("IsServiceContainer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Moved the existing `enable` and `disable` commands to under `nitro service`. Added a `nitro service ls` command that shows the service containers.

### Related issues

- #378 