### PR TITLE
Adds the run command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added common Linux build tools such as make to the app containers.
 - Yarn is now installed by default.
 - Added the ability to exclude directories from app bind mounts to improve performance. ([#419](https://github.com/craftcms/nitro/issues/419))
+- Added `run` command to run one-off containers in an existing directory.
 
 ### Changed
 - Renamed sites to apps and updated the commands. ([#420](https://github.com/craftcms/nitro/issues/420))

--- a/command/nitro/nitro.go
+++ b/command/nitro/nitro.go
@@ -34,6 +34,7 @@ import (
 	"github.com/craftcms/nitro/command/remove"
 	"github.com/craftcms/nitro/command/restart"
 	"github.com/craftcms/nitro/command/resume"
+	"github.com/craftcms/nitro/command/run"
 	"github.com/craftcms/nitro/command/selfupdate"
 	"github.com/craftcms/nitro/command/share"
 	"github.com/craftcms/nitro/command/ssh"
@@ -131,6 +132,7 @@ func NewCommand() *cobra.Command {
 		queue.NewCommand(home, docker, term),
 		remove.NewCommand(home, docker, term),
 		restart.NewCommand(home, docker, term),
+		run.NewCommand(home, docker, term),
 		selfupdate.NewCommand(term),
 		share.NewCommand(home, docker, term),
 		ssh.NewCommand(home, docker, term),

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -81,7 +81,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			// should the container be interactive
 			if flagInteractive {
-				c.Args = append(c.Args, "-it")
+				c.Args = append(c.Args, "--interactive")
 			}
 
 			// if the working dir is set, grab the current directory and mount it

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -1,6 +1,8 @@
 package run
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/docker/docker/client"
@@ -18,6 +20,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 		Short:   "Runs a container.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// find the docker executable
 			path, err := exec.LookPath("docker")
 			if err != nil {
 				return err
@@ -25,21 +28,43 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			c := exec.Command(path, "run")
 
+			// set stdout/stdin/stderr
 			c.Stdin = cmd.InOrStdin()
 			c.Stderr = cmd.ErrOrStderr()
 			c.Stdout = cmd.OutOrStdout()
 
+			// should the container bew removed after completion?
 			if cmd.Flag("remove").Value.String() == "true" {
 				c.Args = append(c.Args, "--rm")
 			}
 
+			// should the container be interactive
 			if cmd.Flag("interactive").Value.String() == "true" {
 				c.Args = append(c.Args, "-it")
 			}
 
+			// if the working dir is set, grab the current directory and mount it
+			if cmd.Flag("working-dir").Value.String() != "" {
+				// get the working dir
+				wd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+
+				c.Args = append(c.Args, "-v")
+
+				vol := fmt.Sprintf("%s:%s", wd, cmd.Flag("working-dir").Value.String())
+
+				c.Args = append(c.Args, vol)
+			}
+
+			// set the image to use, if the image is not found docker will pull it
 			c.Args = append(c.Args, cmd.Flag("image").Value.String())
 
+			// append the args to the container
 			c.Args = append(c.Args, args...)
+
+			fmt.Println(c.Args)
 
 			return c.Run()
 		},

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	flagImage, flagWorkingDir             string
-	flagInteractive, flagPull, flagRemove bool
+	flagImage, flagWorkingDir              string
+	flagInteractive, flagPull, flagPersist bool
 )
 
 const exampleText = `  # run one off containers
@@ -78,7 +78,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			c.Stdout = cmd.OutOrStdout()
 
 			// should the container be removed after completion?
-			if flagRemove {
+			if flagPersist {
 				c.Args = append(c.Args, "--rm")
 			}
 
@@ -116,7 +116,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 	cmd.Flags().StringVar(&flagWorkingDir, "working-dir", "", "working directory for the container")
 	cmd.Flags().BoolVar(&flagInteractive, "interactive", true, "should the container be interactive?")
 	cmd.Flags().StringVar(&flagImage, "image", "", "image to use for the container")
-	cmd.Flags().BoolVar(&flagRemove, "persist", true, "persist container after completion")
+	cmd.Flags().BoolVar(&flagPersist, "persist", true, "persist container after completion")
 	cmd.Flags().BoolVar(&flagPull, "pull", false, "pull the image, even if its been downloaded once")
 
 	cmd.MarkFlagRequired("image")

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	flagImage, flagWorkingDir              string
-	flagInteractive, flagPull, flagPersist bool
+	flagEntrypoint, flagImage, flagPublish, flagWorkingDir string
+	flagInteractive, flagPull, flagPersist                 bool
 )
 
 const exampleText = `  # run one off containers
@@ -87,6 +87,16 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 				c.Args = append(c.Args, "-it")
 			}
 
+			// should we override the entrypoint
+			if flagEntrypoint != "" {
+				c.Args = append(c.Args, "--entrypoint="+flagEntrypoint)
+			}
+
+			// should we publish all the ports to the host machine?
+			if flagPublish != "" {
+				c.Args = append(c.Args, "--publish="+flagPublish)
+			}
+
 			// if the working dir is set, grab the current directory and mount it
 			if flagWorkingDir != "" {
 				// get the working dir
@@ -113,10 +123,12 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 	}
 
 	// set flags for the command
+	cmd.Flags().StringVar(&flagEntrypoint, "entrypoint", "", "override the image entrypoint")
 	cmd.Flags().StringVar(&flagWorkingDir, "working-dir", "", "working directory for the container")
 	cmd.Flags().BoolVar(&flagInteractive, "interactive", true, "should the container be interactive?")
 	cmd.Flags().StringVar(&flagImage, "image", "", "image to use for the container")
 	cmd.Flags().BoolVar(&flagPersist, "persist", true, "persist container after completion")
+	cmd.Flags().StringVar(&flagPublish, "publish", "", "publish a port to the host machine")
 	cmd.Flags().BoolVar(&flagPull, "pull", false, "pull the image, even if its been downloaded once")
 
 	cmd.MarkFlagRequired("image")

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -39,7 +39,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			c.Args = append(c.Args, cmd.Flag("image").Value.String())
 
-			// TODO(jasonmccallister) grab the args for the container commands
+			c.Args = append(c.Args, args...)
 
 			return c.Run()
 		},

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -92,7 +92,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 
-				c.Args = append(c.Args, "-v")
+				c.Args = append(c.Args, "--volume")
 
 				vol := fmt.Sprintf("%s:%s", current, flagWorkingDir)
 

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -20,7 +20,10 @@ var (
 )
 
 const exampleText = `  # run one off containers
-  nitro run`
+  nitro run --image node:10 --working-dir /app install
+
+  # run a composer container, mounting the current directory with a shell inside the container
+  nitro run --image composer --working-dir /app bash`
 
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -81,7 +84,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			// should the container be interactive
 			if flagInteractive {
-				c.Args = append(c.Args, "--interactive")
+				c.Args = append(c.Args, "-it")
 			}
 
 			// if the working dir is set, grab the current directory and mount it
@@ -92,7 +95,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 					return err
 				}
 
-				c.Args = append(c.Args, "--volume")
+				c.Args = append(c.Args, "-v")
 
 				vol := fmt.Sprintf("%s:%s", current, flagWorkingDir)
 

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -24,7 +24,10 @@ const exampleText = `  # run one-off containers
   nitro run --image node:10 --working-dir /app install
 
   # run a composer container, mounting the current directory with a shell inside the container
-  nitro run --image composer --working-dir /app bash`
+  nitro run --image composer --working-dir /app bash
+
+  # run a composer container and pass in commands with special chars
+  nitro run --image composer --working-dir /app --command 'install --ignore-platform-reqs'`
 
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -19,7 +19,7 @@ var (
 	flagInteractive, flagPull, flagPersist                 bool
 )
 
-const exampleText = `  # run one off containers
+const exampleText = `  # run one-off containers
   nitro run --image node:10 --working-dir /app install
 
   # run a composer container, mounting the current directory with a shell inside the container

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -11,6 +11,11 @@ import (
 	"github.com/craftcms/nitro/pkg/terminal"
 )
 
+var (
+	flagImage, flagWorkingDir   string
+	flagInteractive, flagRemove bool
+)
+
 const exampleText = `  # run one off containers
   nitro run`
 
@@ -34,32 +39,32 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			c.Stdout = cmd.OutOrStdout()
 
 			// should the container bew removed after completion?
-			if cmd.Flag("remove").Value.String() == "true" {
+			if flagRemove {
 				c.Args = append(c.Args, "--rm")
 			}
 
 			// should the container be interactive
-			if cmd.Flag("interactive").Value.String() == "true" {
+			if flagInteractive {
 				c.Args = append(c.Args, "-it")
 			}
 
 			// if the working dir is set, grab the current directory and mount it
-			if cmd.Flag("working-dir").Value.String() != "" {
+			if flagWorkingDir != "" {
 				// get the working dir
-				wd, err := os.Getwd()
+				current, err := os.Getwd()
 				if err != nil {
 					return err
 				}
 
 				c.Args = append(c.Args, "-v")
 
-				vol := fmt.Sprintf("%s:%s", wd, cmd.Flag("working-dir").Value.String())
+				vol := fmt.Sprintf("%s:%s", current, flagWorkingDir)
 
 				c.Args = append(c.Args, vol)
 			}
 
 			// set the image to use, if the image is not found docker will pull it
-			c.Args = append(c.Args, cmd.Flag("image").Value.String())
+			c.Args = append(c.Args, flagImage)
 
 			// append the args to the container
 			c.Args = append(c.Args, args...)
@@ -71,10 +76,11 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 	}
 
 	// set flags for the command
-	cmd.Flags().String("working-dir", "", "sets the working directory for the container")
-	cmd.Flags().Bool("interactive", true, "")
-	cmd.Flags().String("image", "", "")
-	cmd.Flags().Bool("remove", true, "")
+	cmd.Flags().StringVar(&flagWorkingDir, "working-dir", "", "working directory for the container")
+	cmd.Flags().BoolVar(&flagInteractive, "interactive", true, "should the container be interactive?")
+	cmd.Flags().StringVar(&flagImage, "image", "", "image to use for the container")
+	cmd.Flags().BoolVar(&flagRemove, "persist", true, "persist container after completion")
+	cmd.MarkFlagRequired("image")
 
 	return cmd
 }

--- a/command/run/run.go
+++ b/command/run/run.go
@@ -1,0 +1,55 @@
+package run
+
+import (
+	"os/exec"
+
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+
+	"github.com/craftcms/nitro/pkg/terminal"
+)
+
+const exampleText = `  # run one off containers
+  nitro run`
+
+func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "run",
+		Short:   "Runs a container.",
+		Example: exampleText,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := exec.LookPath("docker")
+			if err != nil {
+				return err
+			}
+
+			c := exec.Command(path, "run")
+
+			c.Stdin = cmd.InOrStdin()
+			c.Stderr = cmd.ErrOrStderr()
+			c.Stdout = cmd.OutOrStdout()
+
+			if cmd.Flag("remove").Value.String() == "true" {
+				c.Args = append(c.Args, "--rm")
+			}
+
+			if cmd.Flag("interactive").Value.String() == "true" {
+				c.Args = append(c.Args, "-it")
+			}
+
+			c.Args = append(c.Args, cmd.Flag("image").Value.String())
+
+			// TODO(jasonmccallister) grab the args for the container commands
+
+			return c.Run()
+		},
+	}
+
+	// set flags for the command
+	cmd.Flags().String("working-dir", "", "sets the working directory for the container")
+	cmd.Flags().Bool("interactive", true, "")
+	cmd.Flags().String("image", "", "")
+	cmd.Flags().Bool("remove", true, "")
+
+	return cmd
+}


### PR DESCRIPTION
### Description

Adds the `run` command in Nitro which allows running any image anywhere with sensible syntax around the docker run command.

If you need to run a composer command on a host directory, not tied to an app, the `run` command could be used like so:

```bash
nitro run --image composer --interactive help
```

