### PR TITLE
Add optional --command arg

### DIFF
--- a/command/run/run.go
+++ b/command/run/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -15,8 +16,8 @@ import (
 )
 
 var (
-	flagEntrypoint, flagImage, flagPublish, flagWorkingDir string
-	flagInteractive, flagPull, flagPersist                 bool
+	flagEntrypoint, flagImage, flagPublish, flagWorkingDir, flagCommand string
+	flagInteractive, flagPull, flagPersist                              bool
 )
 
 const exampleText = `  # run one-off containers
@@ -115,6 +116,11 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 			// set the image to use, if the image is not found docker will pull it
 			c.Args = append(c.Args, flagImage)
 
+			// optionally use command flag, so we can pass flags without worrying about validating
+			if flagCommand != "" {
+				args = strings.Fields(flagCommand)
+			}
+
 			// append the args to the container
 			c.Args = append(c.Args, args...)
 
@@ -130,6 +136,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 	cmd.Flags().BoolVar(&flagPersist, "persist", true, "persist container after completion")
 	cmd.Flags().StringVar(&flagPublish, "publish", "", "publish a port to the host machine")
 	cmd.Flags().BoolVar(&flagPull, "pull", false, "pull the image, even if its been downloaded once")
+	cmd.Flags().StringVar(&flagCommand, "command", "", "command to run in the container")
 
 	cmd.MarkFlagRequired("image")
 


### PR DESCRIPTION
With this change you could now run:

```
nitro run --image node:10 --command 'npm install --prefix /app/'
```

Note that it is optional, so if you command doesn't need flags, you can run as before, eg:

```
nitro run --image node:10 ls ./usr
```