### PR TITLE
Improve `ls` command wording

### DIFF
--- a/command/ls/ls.go
+++ b/command/ls/ls.go
@@ -31,7 +31,7 @@ var (
 func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outputer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "ls",
-		Short:   "Lists details for Nitro’s containers.",
+		Short:   "Lists Nitro container details.",
 		Example: exampleText,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -127,7 +127,7 @@ func NewCommand(home string, docker client.CommonAPIClient, output terminal.Outp
 
 			tbl.Print()
 
-			fmt.Println("\nNote: Database containers have the username `nitro` and password `nitro`.")
+			fmt.Println("\n💡 Each database container’s username+password is `nitro`+`nitro`.")
 			fmt.Println("")
 
 			return nil


### PR DESCRIPTION
### Description

Minor edits to shorten the help description and warm up the username+password note replacing `Note:` with a lightbulb emoji similar to how we’d style tips in READMEs and the docs. Hopefully each one is quicker to scan using a human brain.

![Screen Shot 2022-01-19 at 09 24 45 AM@2x](https://user-images.githubusercontent.com/2488775/150182602-129736c3-59ba-4124-bddd-8acfd0a1dbf9.png)
