### PR TITLE
Remove aggressive headers that cannot be overridden

### DIFF
--- a/image/nginx/default.conf
+++ b/image/nginx/default.conf
@@ -27,7 +27,4 @@ server {
     location ~ \.php$ {
         include nitro/php_fastcgi.conf;
     }
-
-    # allow cors
-    add_header Access-Control-Allow-Origin *;
 }

--- a/image/nitro/security.conf
+++ b/image/nitro/security.conf
@@ -1,10 +1,3 @@
-# security headers
-add_header X-Frame-Options "SAMEORIGIN" always;
-add_header X-XSS-Protection "1; mode=block" always;
-add_header X-Content-Type-Options "nosniff" always;
-add_header Referrer-Policy "no-referrer-when-downgrade" always;
-#add_header Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
-
 # . files
 location ~ /\.(?!well-known) {
     deny all;


### PR DESCRIPTION
These headers are problematic for a few reasons:

- using `add_header` unconditionally means they will _always_ be added to the response. This means, eg, if Craft tries to add a `Content-Security-Policy` header, you'll end up 2 `Content-Security-Policy` headers, which results in a CORS error
- Similarly, there is no way to unset a header set by nginx when you need to, like `X-Frame-Options`

Most of these issues appear with multisite and preview, as you're dealing with multiple domains.
As a rule though, I don't think we should set any headers that _could_ be set in PHP/Craft, as it means they cannot be overridden in the response.