### PR TITLE
Bugfix 'opcache_validate_timestamps' isn't set correctly if defined i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Craft Nitro
 
+## Unreleased
+
+### Fixed
+- Fixed a bug where `opcache_validate_timestamps` isn't correctly set. ([#435](https://github.com/craftcms/nitro/issues/435))
+
 ## 2.0.9 - 2022-02-15
 
 ### Added

--- a/command/apply/internal/match/match.go
+++ b/command/apply/internal/match/match.go
@@ -176,8 +176,7 @@ func checkEnvs(site config.Site, blackfire config.Blackfire, envs []string) bool
 					return false
 				}
 			case "PHP_OPCACHE_VALIDATE_TIMESTAMPS":
-				// if there is a custom value
-				if !site.PHP.OpcacheValidateTimestamps && val != config.DefaultEnvs[env] {
+				if (site.PHP.OpcacheValidateTimestamps && val == config.DefaultEnvs[env]) || (!site.PHP.OpcacheValidateTimestamps && val != config.DefaultEnvs[env]) {
 					return false
 				}
 			case "XDEBUG_MODE":

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -760,7 +760,7 @@ func phpVars(php PHP, version string) []string {
 	}
 
 	if php.OpcacheValidateTimestamps {
-		envs = append(envs, "PHP_OPCACHE_VALIDATE_TIMESTAMPS="+DefaultEnvs["PHP_OPCACHE_VALIDATE_TIMESTAMPS"])
+		envs = append(envs, "PHP_OPCACHE_VALIDATE_TIMESTAMPS=1")
 	} else {
 		envs = append(envs, "PHP_OPCACHE_VALIDATE_TIMESTAMPS="+DefaultEnvs["PHP_OPCACHE_VALIDATE_TIMESTAMPS"])
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -31,14 +31,15 @@ func TestSite_AsEnvs(t *testing.T) {
 			fields: fields{
 				Hostname: "somewebsite.nitro",
 				PHP: PHP{
-					DisplayErrors:         true,
-					MemoryLimit:           "256M",
-					MaxExecutionTime:      3000,
-					UploadMaxFileSize:     "128M",
-					MaxInputVars:          2000,
-					PostMaxSize:           "128M",
-					OpcacheEnable:         true,
-					OpcacheRevalidateFreq: 60,
+					DisplayErrors            : true,
+					MemoryLimit              : "256M",
+					MaxExecutionTime         : 3000,
+					UploadMaxFileSize        : "128M",
+					MaxInputVars             : 2000,
+					PostMaxSize              : "128M",
+					OpcacheEnable            : true,
+					OpcacheRevalidateFreq    : 60,
+					OpcacheValidateTimestamps: false,
 				},
 				Version: "7.1",
 				Xdebug:  true,
@@ -68,14 +69,15 @@ func TestSite_AsEnvs(t *testing.T) {
 			fields: fields{
 				Hostname: "somewebsite.nitro",
 				PHP: PHP{
-					DisplayErrors:         true,
-					MemoryLimit:           "256M",
-					MaxExecutionTime:      3000,
-					UploadMaxFileSize:     "128M",
-					MaxInputVars:          2000,
-					PostMaxSize:           "128M",
-					OpcacheEnable:         true,
-					OpcacheRevalidateFreq: 60,
+					DisplayErrors            : true,
+					MemoryLimit              : "256M",
+					MaxExecutionTime         : 3000,
+					UploadMaxFileSize        : "128M",
+					MaxInputVars             : 2000,
+					PostMaxSize              : "128M",
+					OpcacheEnable            : true,
+					OpcacheRevalidateFreq    : 60,
+					OpcacheValidateTimestamps: false,
 				},
 				Version: "7.4",
 				Xdebug:  true,
@@ -105,14 +107,15 @@ func TestSite_AsEnvs(t *testing.T) {
 			fields: fields{
 				Hostname: "somewebsite.nitro",
 				PHP: PHP{
-					DisplayErrors:         true,
-					MemoryLimit:           "256M",
-					MaxExecutionTime:      3000,
-					UploadMaxFileSize:     "128M",
-					MaxInputVars:          2000,
-					PostMaxSize:           "128M",
-					OpcacheEnable:         true,
-					OpcacheRevalidateFreq: 60,
+					DisplayErrors            : true,
+					MemoryLimit              : "256M",
+					MaxExecutionTime         : 3000,
+					UploadMaxFileSize        : "128M",
+					MaxInputVars             : 2000,
+					PostMaxSize              : "128M",
+					OpcacheEnable            : true,
+					OpcacheRevalidateFreq    : 60,
+					OpcacheValidateTimestamps: false,
 				},
 			},
 			want: []string{
@@ -820,6 +823,11 @@ func TestConfig_SetPHPBoolSetting(t *testing.T) {
 			case "opcache_enable":
 				if site.PHP.OpcacheEnable != tt.args.value {
 					t.Errorf("expected the setting to be %v, got %v", tt.args.value, site.PHP.OpcacheEnable)
+				}
+			}
+			case "opcache_validate_timestamps":
+				if site.PHP.OpcacheValidateTimestamps != tt.args.value {
+					t.Errorf("expected the setting to be %v, got %v", tt.args.value, site.PHP.OpcacheValidateTimestamps)
 				}
 			}
 		})

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -824,7 +824,6 @@ func TestConfig_SetPHPBoolSetting(t *testing.T) {
 				if site.PHP.OpcacheEnable != tt.args.value {
 					t.Errorf("expected the setting to be %v, got %v", tt.args.value, site.PHP.OpcacheEnable)
 				}
-			}
 			case "opcache_validate_timestamps":
 				if site.PHP.OpcacheValidateTimestamps != tt.args.value {
 					t.Errorf("expected the setting to be %v, got %v", tt.args.value, site.PHP.OpcacheValidateTimestamps)


### PR DESCRIPTION
…n nitro.yml

### Description
When you set `opcache_validate_timestamps` trough `nitro iniset` the setting won't be applied to the Docker container. The changes will provide you with a working `opcache_validate_timestamps` value.


### Related issues
- [ini setting opcache_validate_timestamps doesn't seem to work #435](https://github.com/craftcms/nitro/issues/435)
